### PR TITLE
Add Text Input Widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ resolver = "2"
 [patch.crates-io]
 # easygpu = { path = "../easygpu" }
 bonsaidb = { git = "https://github.com/khonsulabs/bonsaidb.git", branch = "main" }
-easygpu = { path = "../easygpu/easygpu" }
-easygpu-lyon = { path = "../easygpu/lyon" }
+easygpu = { git = "https://github.com/khonsulabs/easygpu.git", branch = "main" }
+easygpu-lyon = { git = "https://github.com/khonsulabs/easygpu.git", branch = "main" }
 # bonsaidb = { path="../bonsaidb/bonsaidb" }
 # actionable = { git="https://github.com/khonsulabs/actionable.git", branch="main" }
 # actionable = { path="../actionable/actionable", version="0.1.0-dev.3" }
@@ -27,11 +27,11 @@ easygpu-lyon = { path = "../easygpu/lyon" }
 # [patch."https://github.com/khonsulabs/stylecs.git"]
 # stylecs = { path = "../stylecs/stylecs" }
 
-[patch."https://github.com/khonsulabs/kludgine.git"]
-kludgine = { path = "../kludgine/kludgine" }
+# [patch."https://github.com/khonsulabs/kludgine.git"]
+# kludgine = { path = "../kludgine/kludgine" }
 
-[patch."https://github.com/khonsulabs/figures.git"]
-figures = { path = "../figures/figures" }
+# [patch."https://github.com/khonsulabs/figures.git"]
+# figures = { path = "../figures/figures" }
 
 # [patch."https://github.com/khonsulabs/khonsu-tools.git"]
 # khonsu-tools = { path="../khonsu-tools" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ resolver = "2"
 [patch.crates-io]
 # easygpu = { path = "../easygpu" }
 bonsaidb = { git = "https://github.com/khonsulabs/bonsaidb.git", branch = "main" }
-easygpu = { path = "../easygpu" }
-easygpu-lyon = { path = "../easygpu-lyon" }
+easygpu = { path = "../easygpu/easygpu" }
+easygpu-lyon = { path = "../easygpu/lyon" }
 # bonsaidb = { path="../bonsaidb/bonsaidb" }
 # actionable = { git="https://github.com/khonsulabs/actionable.git", branch="main" }
 # actionable = { path="../actionable/actionable", version="0.1.0-dev.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ resolver = "2"
 
 [patch.crates-io]
 # easygpu = { path = "../easygpu" }
-bonsaidb = { git="https://github.com/khonsulabs/bonsaidb.git", branch="main" }
+bonsaidb = { git = "https://github.com/khonsulabs/bonsaidb.git", branch = "main" }
+easygpu = { path = "../easygpu" }
+easygpu-lyon = { path = "../easygpu-lyon" }
 # bonsaidb = { path="../bonsaidb/bonsaidb" }
 # actionable = { git="https://github.com/khonsulabs/actionable.git", branch="main" }
 # actionable = { path="../actionable/actionable", version="0.1.0-dev.3" }
@@ -25,8 +27,11 @@ bonsaidb = { git="https://github.com/khonsulabs/bonsaidb.git", branch="main" }
 # [patch."https://github.com/khonsulabs/stylecs.git"]
 # stylecs = { path = "../stylecs/stylecs" }
 
-# [patch."https://github.com/khonsulabs/kludgine.git"]
-# kludgine = { path = "../kludgine/kludgine" }
+[patch."https://github.com/khonsulabs/kludgine.git"]
+kludgine = { path = "../kludgine/kludgine" }
+
+[patch."https://github.com/khonsulabs/figures.git"]
+figures = { path = "../figures/figures" }
 
 # [patch."https://github.com/khonsulabs/khonsu-tools.git"]
 # khonsu-tools = { path="../khonsu-tools" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,3 +20,6 @@ palette = "0.6"
 log = "0.4"
 url = "2"
 parking_lot = "0.11"
+
+[target.'cfg(target_arch="wasm32")'.dependencies]
+parking_lot = { version = "0.11", features = ["wasm-bindgen"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-euclid = "0.22"
+figures = { git = "https://github.com/khonsulabs/figures.git", branch = "main" }
 stylecs = { git = "https://github.com/khonsulabs/stylecs.git", branch = "main" }
 flume = "0.10"
 palette = "0.6"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,8 +14,9 @@ readme = "../README.md"
 
 [dependencies]
 euclid = "0.22"
-stylecs = { git="https://github.com/khonsulabs/stylecs.git", branch="main" }
+stylecs = { git = "https://github.com/khonsulabs/stylecs.git", branch = "main" }
 flume = "0.10"
 palette = "0.6"
 log = "0.4"
 url = "2"
+parking_lot = "0.11"

--- a/core/src/assets.rs
+++ b/core/src/assets.rs
@@ -1,9 +1,6 @@
-use std::{
-    borrow::Cow,
-    path::PathBuf,
-    sync::{Arc, Mutex},
-};
+use std::{borrow::Cow, path::PathBuf, sync::Arc};
 
+use parking_lot::Mutex;
 use url::Url;
 
 use crate::{AnyFrontend, AnySendSync, Callback};
@@ -83,7 +80,6 @@ pub struct Image {
 impl Image {
     /// Loads the image. When loaded successfully, `on_loaded` will be invoked.
     /// If an error occurs while loading, `on_error` will be invoked.
-    #[allow(clippy::missing_panics_doc)]
     pub fn load(
         &self,
         on_loaded: Callback<Image>,
@@ -94,17 +90,15 @@ impl Image {
     }
 
     /// Sets the internal frontend data for this image. Should not be used outside of developing a frontend.
-    #[allow(clippy::missing_panics_doc)]
     pub fn set_data<D: AnySendSync>(&self, new_data: D) {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         *data = Some(Box::new(new_data) as Box<dyn AnySendSync>);
     }
 
     /// Maps the frontend data into `callback` returning the result of the
     /// function. This is generally only useful when developing a frontend.
-    #[allow(clippy::missing_panics_doc)]
     pub fn map_data<R, F: FnOnce(Option<&mut dyn AnySendSync>) -> R>(&self, callback: F) -> R {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         callback(data.as_deref_mut())
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,7 +20,7 @@ mod gooey;
 pub mod styles;
 mod widget;
 
-pub use euclid;
+pub use figures;
 pub use palette;
 pub use url;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,7 +35,7 @@ pub type Pixels = figures::Pixels;
 /// system user interface settings, and the browser's zoom level. Each
 /// [`Frontend`] will use its best available methods for translating `Points` to
 /// [`Pixels`] in a way that is consistent with other applications.
-pub type Points = figures::Scaled;
+pub type Scaled = figures::Scaled;
 
 /// The name of the class assigned to the root widget of a window.
 pub const ROOT_CLASS: &str = "gooey-root";

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -30,10 +30,10 @@ pub use self::{frontend::*, gooey::*, widget::*};
 pub type Pixels = figures::Pixels;
 
 /// A unit aiming to represent the scaled resolution of the display the
-/// interface is being displayed on. The ratio between [`Pixels`] and `Points`
+/// interface is being displayed on. The ratio between [`Pixels`] and `Scaled`
 /// can vary based on many things, including the display configuration, the
 /// system user interface settings, and the browser's zoom level. Each
-/// [`Frontend`] will use its best available methods for translating `Points` to
+/// [`Frontend`] will use its best available methods for translating `Scaled` to
 /// [`Pixels`] in a way that is consistent with other applications.
 pub type Scaled = figures::Scaled;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -27,8 +27,7 @@ pub use url;
 pub use self::{frontend::*, gooey::*, widget::*};
 
 /// A unit representing physical pixels on a display.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Pixels;
+pub type Pixels = figures::Pixels;
 
 /// A unit aiming to represent the scaled resolution of the display the
 /// interface is being displayed on. The ratio between [`Pixels`] and `Points`
@@ -36,8 +35,7 @@ pub struct Pixels;
 /// system user interface settings, and the browser's zoom level. Each
 /// [`Frontend`] will use its best available methods for translating `Points` to
 /// [`Pixels`] in a way that is consistent with other applications.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Points;
+pub type Points = figures::Scaled;
 
 /// The name of the class assigned to the root widget of a window.
 pub const ROOT_CLASS: &str = "gooey-root";

--- a/core/src/styles/border.rs
+++ b/core/src/styles/border.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut};
 use figures::Figure;
 use stylecs::StyleComponent;
 
-use super::{Color, Surround};
+use super::{ColorPair, Surround};
 use crate::Scaled;
 
 /// A border around a widget.
@@ -30,12 +30,12 @@ pub struct BorderOptions {
     /// The width of the border.
     pub width: Figure<f32, Scaled>,
     /// The color of the border.
-    pub color: Color,
+    pub color: ColorPair,
 }
 
 impl BorderOptions {
     /// Returns a new border with `width` and `color`.
-    pub const fn new(width: f32, color: Color) -> Self {
+    pub const fn new(width: f32, color: ColorPair) -> Self {
         Self {
             width: Figure::new(width),
             color,
@@ -47,7 +47,7 @@ impl From<Figure<f32, Scaled>> for BorderOptions {
     fn from(width: Figure<f32, Scaled>) -> Self {
         Self {
             width,
-            color: Color::default(),
+            color: ColorPair::default(),
         }
     }
 }

--- a/core/src/styles/border.rs
+++ b/core/src/styles/border.rs
@@ -4,7 +4,7 @@ use figures::Figure;
 use stylecs::StyleComponent;
 
 use super::{Color, Surround};
-use crate::Points;
+use crate::Scaled;
 
 /// A border around a widget.
 #[derive(Default, Debug, Clone)]
@@ -28,7 +28,7 @@ impl Border {
 #[must_use]
 pub struct BorderOptions {
     /// The width of the border.
-    pub width: Figure<f32, Points>,
+    pub width: Figure<f32, Scaled>,
     /// The color of the border.
     pub color: Color,
 }
@@ -43,8 +43,8 @@ impl BorderOptions {
     }
 }
 
-impl From<Figure<f32, Points>> for BorderOptions {
-    fn from(width: Figure<f32, Points>) -> Self {
+impl From<Figure<f32, Scaled>> for BorderOptions {
+    fn from(width: Figure<f32, Scaled>) -> Self {
         Self {
             width,
             color: Color::default(),
@@ -52,7 +52,7 @@ impl From<Figure<f32, Points>> for BorderOptions {
     }
 }
 
-impl From<BorderOptions> for Figure<f32, Points> {
+impl From<BorderOptions> for Figure<f32, Scaled> {
     fn from(opts: BorderOptions) -> Self {
         opts.width
     }

--- a/core/src/styles/border.rs
+++ b/core/src/styles/border.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use euclid::Length;
+use figures::Figure;
 use stylecs::StyleComponent;
 
 use super::{Color, Surround};
@@ -28,7 +28,7 @@ impl Border {
 #[must_use]
 pub struct BorderOptions {
     /// The width of the border.
-    pub width: Length<f32, Points>,
+    pub width: Figure<f32, Points>,
     /// The color of the border.
     pub color: Color,
 }
@@ -37,14 +37,14 @@ impl BorderOptions {
     /// Returns a new border with `width` and `color`.
     pub const fn new(width: f32, color: Color) -> Self {
         Self {
-            width: Length::new(width),
+            width: Figure::new(width),
             color,
         }
     }
 }
 
-impl From<Length<f32, Points>> for BorderOptions {
-    fn from(width: Length<f32, Points>) -> Self {
+impl From<Figure<f32, Points>> for BorderOptions {
+    fn from(width: Figure<f32, Points>) -> Self {
         Self {
             width,
             color: Color::default(),
@@ -52,7 +52,7 @@ impl From<Length<f32, Points>> for BorderOptions {
     }
 }
 
-impl From<BorderOptions> for Length<f32, Points> {
+impl From<BorderOptions> for Figure<f32, Points> {
     fn from(opts: BorderOptions) -> Self {
         opts.width
     }

--- a/core/src/styles/border.rs
+++ b/core/src/styles/border.rs
@@ -24,7 +24,7 @@ impl Border {
 }
 
 /// Options for a single side of a [`Border`].
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Copy, Clone)]
 #[must_use]
 pub struct BorderOptions {
     /// The width of the border.

--- a/core/src/styles/font_size.rs
+++ b/core/src/styles/font_size.rs
@@ -1,11 +1,11 @@
 use figures::Figure;
 use stylecs::StyleComponent;
 
-use crate::Points;
+use crate::Scaled;
 
 /// The font size for drawing text.
 #[derive(Debug, Copy, Clone)]
-pub struct FontSize(pub Figure<f32, Points>);
+pub struct FontSize(pub Figure<f32, Scaled>);
 
 impl Default for FontSize {
     fn default() -> Self {
@@ -28,7 +28,7 @@ impl FontSize {
 
     /// Returns the font size as a type-safe measurement.
     #[must_use]
-    pub const fn length(self) -> Figure<f32, Points> {
+    pub const fn length(self) -> Figure<f32, Scaled> {
         self.0
     }
 }

--- a/core/src/styles/font_size.rs
+++ b/core/src/styles/font_size.rs
@@ -1,11 +1,11 @@
-use euclid::Length;
+use figures::Figure;
 use stylecs::StyleComponent;
 
 use crate::Points;
 
 /// The font size for drawing text.
 #[derive(Debug, Copy, Clone)]
-pub struct FontSize(pub Length<f32, Points>);
+pub struct FontSize(pub Figure<f32, Points>);
 
 impl Default for FontSize {
     fn default() -> Self {
@@ -17,7 +17,7 @@ impl FontSize {
     /// Creates a new `FontSize` using `value` in `Unit`.
     #[must_use]
     pub const fn new(value: f32) -> Self {
-        Self(Length::new(value))
+        Self(Figure::new(value))
     }
 
     /// Returns the raw font size value.
@@ -28,7 +28,7 @@ impl FontSize {
 
     /// Returns the font size as a type-safe measurement.
     #[must_use]
-    pub const fn length(self) -> Length<f32, Points> {
+    pub const fn length(self) -> Figure<f32, Points> {
         self.0
     }
 }

--- a/core/src/styles/lines.rs
+++ b/core/src/styles/lines.rs
@@ -1,9 +1,9 @@
 use figures::Figure;
 use stylecs::StyleComponent;
 
-use crate::Points;
+use crate::Scaled;
 
-/// The width of lines stroked/drawn. Default is `1.` [`Points`].
+/// The width of lines stroked/drawn. Default is `1.` [`Scaled`].
 #[derive(Debug, Copy)]
 pub struct LineWidth<Unit>(pub Figure<f32, Unit>);
 
@@ -13,7 +13,7 @@ impl<Unit> Clone for LineWidth<Unit> {
     }
 }
 
-impl Default for LineWidth<Points> {
+impl Default for LineWidth<Scaled> {
     fn default() -> Self {
         Self::new(1.)
     }
@@ -39,4 +39,4 @@ impl<Unit> LineWidth<Unit> {
     }
 }
 
-impl StyleComponent for LineWidth<Points> {}
+impl StyleComponent for LineWidth<Scaled> {}

--- a/core/src/styles/lines.rs
+++ b/core/src/styles/lines.rs
@@ -1,11 +1,11 @@
-use euclid::Length;
+use figures::Figure;
 use stylecs::StyleComponent;
 
 use crate::Points;
 
 /// The width of lines stroked/drawn. Default is `1.` [`Points`].
 #[derive(Debug, Copy)]
-pub struct LineWidth<Unit>(pub Length<f32, Unit>);
+pub struct LineWidth<Unit>(pub Figure<f32, Unit>);
 
 impl<Unit> Clone for LineWidth<Unit> {
     fn clone(&self) -> Self {
@@ -23,7 +23,7 @@ impl<Unit> LineWidth<Unit> {
     /// Creates a new `LineWidth` using `value` in `Unit`.
     #[must_use]
     pub const fn new(value: f32) -> Self {
-        Self(Length::new(value))
+        Self(Figure::new(value))
     }
 
     /// Returns the line width's raw value.
@@ -34,7 +34,7 @@ impl<Unit> LineWidth<Unit> {
 
     /// Returns the line width as a type-safe measurement.
     #[must_use]
-    pub const fn length(&self) -> Length<f32, Unit> {
+    pub const fn length(&self) -> Figure<f32, Unit> {
         self.0
     }
 }

--- a/core/src/styles/padding.rs
+++ b/core/src/styles/padding.rs
@@ -4,12 +4,12 @@ use figures::Figure;
 use stylecs::StyleComponent;
 
 use super::Surround;
-use crate::Points;
+use crate::Scaled;
 
 /// Adds padding (spacing) around a widget.
 #[derive(Debug, Clone, Default)]
 #[must_use]
-pub struct Padding(pub Surround<Figure<f32, Points>>);
+pub struct Padding(pub Surround<Figure<f32, Scaled>>);
 
 impl StyleComponent for Padding {
     fn should_be_inherited(&self) -> bool {
@@ -38,14 +38,14 @@ impl Padding {
     }
 }
 
-impl From<Figure<f32, Points>> for Padding {
-    fn from(length: Figure<f32, Points>) -> Self {
+impl From<Figure<f32, Scaled>> for Padding {
+    fn from(length: Figure<f32, Scaled>) -> Self {
         Self(Surround::from(Some(length)))
     }
 }
 
 impl Deref for Padding {
-    type Target = Surround<Figure<f32, Points>>;
+    type Target = Surround<Figure<f32, Scaled>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/core/src/styles/padding.rs
+++ b/core/src/styles/padding.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use euclid::Length;
+use figures::Figure;
 use stylecs::StyleComponent;
 
 use super::Surround;
@@ -9,7 +9,7 @@ use crate::Points;
 /// Adds padding (spacing) around a widget.
 #[derive(Debug, Clone, Default)]
 #[must_use]
-pub struct Padding(pub Surround<Length<f32, Points>>);
+pub struct Padding(pub Surround<Figure<f32, Points>>);
 
 impl StyleComponent for Padding {
     fn should_be_inherited(&self) -> bool {
@@ -34,18 +34,18 @@ impl Padding {
 
     /// Returns an instance with uniform padding of `points` on all sides.
     pub fn uniform(points: f32) -> Self {
-        Self::from(Length::new(points))
+        Self::from(Figure::new(points))
     }
 }
 
-impl From<Length<f32, Points>> for Padding {
-    fn from(length: Length<f32, Points>) -> Self {
+impl From<Figure<f32, Points>> for Padding {
+    fn from(length: Figure<f32, Points>) -> Self {
         Self(Surround::from(Some(length)))
     }
 }
 
 impl Deref for Padding {
-    type Target = Surround<Length<f32, Points>>;
+    type Target = Surround<Figure<f32, Points>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -68,25 +68,25 @@ pub struct Builder {
 impl Builder {
     /// Sets the left padding to `points`.
     pub fn left(mut self, points: f32) -> Self {
-        self.padding.left = Some(Length::new(points));
+        self.padding.left = Some(Figure::new(points));
         self
     }
 
     /// Sets the right padding to `points`.
     pub fn right(mut self, points: f32) -> Self {
-        self.padding.right = Some(Length::new(points));
+        self.padding.right = Some(Figure::new(points));
         self
     }
 
     /// Sets the top padding to `points`.
     pub fn top(mut self, points: f32) -> Self {
-        self.padding.top = Some(Length::new(points));
+        self.padding.top = Some(Figure::new(points));
         self
     }
 
     /// Sets the bottom padding to `points`.
     pub fn bottom(mut self, points: f32) -> Self {
-        self.padding.bottom = Some(Length::new(points));
+        self.padding.bottom = Some(Figure::new(points));
         self
     }
 

--- a/core/src/styles/surround.rs
+++ b/core/src/styles/surround.rs
@@ -1,6 +1,6 @@
 use figures::{Figure, Size};
 
-use crate::Points;
+use crate::Scaled;
 
 /// Measurements that surrouned a box/rect.
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
@@ -15,24 +15,24 @@ pub struct Surround<T> {
     pub bottom: Option<T>,
 }
 
-impl<T: Into<Figure<f32, Points>> + Clone> Surround<T> {
+impl<T: Into<Figure<f32, Scaled>> + Clone> Surround<T> {
     /// Returns the minimum width that this surround will occupy.
     #[must_use]
-    pub fn minimum_width(&self) -> Figure<f32, Points> {
+    pub fn minimum_width(&self) -> Figure<f32, Scaled> {
         self.left.clone().map(T::into).unwrap_or_default()
             + self.right.clone().map(T::into).unwrap_or_default()
     }
 
     /// Returns the minimum height that this surround will occupy.
     #[must_use]
-    pub fn minimum_height(&self) -> Figure<f32, Points> {
+    pub fn minimum_height(&self) -> Figure<f32, Scaled> {
         self.top.clone().map(T::into).unwrap_or_default()
             + self.bottom.clone().map(T::into).unwrap_or_default()
     }
 
     /// Returns the minimum [`Size`] that this surround will occupy.
     #[must_use]
-    pub fn minimum_size(&self) -> Size<f32, Points> {
+    pub fn minimum_size(&self) -> Size<f32, Scaled> {
         Size::from_figures(self.minimum_width(), self.minimum_height())
     }
 }

--- a/core/src/styles/surround.rs
+++ b/core/src/styles/surround.rs
@@ -1,4 +1,4 @@
-use euclid::{Length, Size2D};
+use figures::{Figure, Size};
 
 use crate::Points;
 
@@ -15,25 +15,25 @@ pub struct Surround<T> {
     pub bottom: Option<T>,
 }
 
-impl<T: Into<Length<f32, Points>> + Clone> Surround<T> {
+impl<T: Into<Figure<f32, Points>> + Clone> Surround<T> {
     /// Returns the minimum width that this surround will occupy.
     #[must_use]
-    pub fn minimum_width(&self) -> Length<f32, Points> {
+    pub fn minimum_width(&self) -> Figure<f32, Points> {
         self.left.clone().map(T::into).unwrap_or_default()
             + self.right.clone().map(T::into).unwrap_or_default()
     }
 
     /// Returns the minimum height that this surround will occupy.
     #[must_use]
-    pub fn minimum_height(&self) -> Length<f32, Points> {
+    pub fn minimum_height(&self) -> Figure<f32, Points> {
         self.top.clone().map(T::into).unwrap_or_default()
             + self.bottom.clone().map(T::into).unwrap_or_default()
     }
 
-    /// Returns the minimum [`Size2D`] that this surround will occupy.
+    /// Returns the minimum [`Size`] that this surround will occupy.
     #[must_use]
-    pub fn minimum_size(&self) -> Size2D<f32, Points> {
-        Size2D::from_lengths(self.minimum_width(), self.minimum_height())
+    pub fn minimum_size(&self) -> Size<f32, Points> {
+        Size::from_figures(self.minimum_width(), self.minimum_height())
     }
 }
 

--- a/frontends/browser/Cargo.toml
+++ b/frontends/browser/Cargo.toml
@@ -44,3 +44,6 @@ log = "0.4.6"
 wasm-logger = "0.2.0"
 once_cell = "1"
 parking_lot = "0.11"
+
+[target.'cfg(target_arch="wasm32")'.dependencies]
+parking_lot = { version = "0.11", features = ["wasm-bindgen"] }

--- a/frontends/browser/Cargo.toml
+++ b/frontends/browser/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../../README.md"
 [dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = { version="0.3", features=[
+web-sys = { version = "0.3", features = [
     "Blob",
     "CssRuleList",
     "CssStyleDeclaration",
@@ -38,8 +38,9 @@ web-sys = { version="0.3", features=[
     "Window",
 ] }
 js-sys = "0.3"
-gooey-core = { path="../../core", version="0.1.0-dev.0" }
+gooey-core = { path = "../../core", version = "0.1.0-dev.0" }
 console_error_panic_hook = "0.1"
 log = "0.4.6"
 wasm-logger = "0.2.0"
 once_cell = "1"
+parking_lot = "0.11"

--- a/frontends/browser/src/lib.rs
+++ b/frontends/browser/src/lib.rs
@@ -25,7 +25,7 @@ use std::{
     ops::Deref,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
-        Arc, Mutex,
+        Arc,
     },
 };
 
@@ -41,6 +41,7 @@ use gooey_core::{
     Transmogrifier, TransmogrifierContext, TransmogrifierState, Widget, WidgetId, WidgetRef,
     WidgetRegistration,
 };
+use parking_lot::Mutex;
 use wasm_bindgen::{prelude::*, JsCast};
 
 pub mod utils;
@@ -210,7 +211,7 @@ fn update_system_theme(root_id: &str, dark: bool, theme: &Mutex<SystemTheme>) {
         (SystemTheme::Light, "gooey-light", "gooey-dark")
     };
 
-    let mut theme = theme.lock().unwrap();
+    let mut theme = theme.lock();
     *theme = system_theme;
 
     let window = web_sys::window().unwrap();
@@ -266,7 +267,7 @@ impl gooey_core::Frontend for WebSys {
     }
 
     fn theme(&self) -> SystemTheme {
-        let theme = self.data.theme.lock().unwrap();
+        let theme = self.data.theme.lock();
         *theme
     }
 

--- a/frontends/browser/src/utils.rs
+++ b/frontends/browser/src/utils.rs
@@ -4,7 +4,7 @@ use std::{
     fmt::Write,
     sync::{
         atomic::{AtomicU32, Ordering},
-        Arc, Mutex,
+        Arc,
     },
 };
 
@@ -17,6 +17,7 @@ use gooey_core::{
     },
 };
 use once_cell::sync::OnceCell;
+use parking_lot::Mutex;
 use wasm_bindgen::JsCast;
 use web_sys::{CssStyleSheet, HtmlElement, HtmlStyleElement};
 
@@ -104,10 +105,7 @@ impl CssManager {
         // for each registered rule and keep our own Vec<> of rules that matches
         // the order of the stylesheet rules. When removing, we can use the
         // index we find the rule inside of the Vec.
-        let mut state = REGISTERED_CSS_RULES
-            .get_or_init(Mutex::default)
-            .lock()
-            .unwrap();
+        let mut state = REGISTERED_CSS_RULES.get_or_init(Mutex::default).lock();
         let id = loop {
             let next_id = LAST_CSS_RULE_ID.fetch_add(1, Ordering::SeqCst);
             if !state.taken_ids.contains(&next_id) {
@@ -135,7 +133,7 @@ impl CssManager {
     }
 
     pub fn unregister_rule(&self, rule: &mut CssRules) {
-        let mut state = REGISTERED_CSS_RULES.get().unwrap().lock().unwrap();
+        let mut state = REGISTERED_CSS_RULES.get().unwrap().lock();
         for rule in std::mem::take(&mut rule.index) {
             let index = state
                 .rules
@@ -310,11 +308,11 @@ impl CssBlockBuilder {
     }
 
     pub fn with_border(self, border: &Border) -> Self {
-        let left = border.left.clone().unwrap_or_default();
-        let right = border.right.clone().unwrap_or_default();
-        let top = border.top.clone().unwrap_or_default();
-        let bottom = border.bottom.clone().unwrap_or_default();
-        let widths_are_same = left.width.clone().approx_eq(&right.width)
+        let left = border.left.unwrap_or_default();
+        let right = border.right.unwrap_or_default();
+        let top = border.top.unwrap_or_default();
+        let bottom = border.bottom.unwrap_or_default();
+        let widths_are_same = left.width.approx_eq(&right.width)
             && top.width.approx_eq(&bottom.width)
             && left.width.approx_eq(&top.width);
         let has_border = !widths_are_same || !left.width.approx_eq(&Length::default());

--- a/frontends/browser/src/utils.rs
+++ b/frontends/browser/src/utils.rs
@@ -11,10 +11,11 @@ use std::{
 use gooey_core::{
     figures::{Approx, Figure},
     styles::{
-        border::{Border, BorderOptions},
+        border::Border,
         style_sheet::{Classes, Rule, State},
-        Padding, StyleComponent, SystemTheme,
+        Color, Padding, StyleComponent, SystemTheme,
     },
+    Scaled,
 };
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
@@ -294,13 +295,13 @@ impl CssBlockBuilder {
         }
     }
 
-    fn with_single_border(self, name: &str, options: &BorderOptions) -> Self {
-        if options.width.get() > 0. {
+    fn with_single_border(self, name: &str, width: Figure<f32, Scaled>, color: Color) -> Self {
+        if width.get() > 0. {
             self.with_css_statement(&format!(
                 "border-{}: {:.03}pt solid {}",
                 name,
-                options.width.get(),
-                options.color.as_css_string()
+                width.get(),
+                color.as_css_string()
             ))
         } else {
             self.with_css_statement(&format!("border-{}: none", name))
@@ -318,22 +319,26 @@ impl CssBlockBuilder {
         let has_border = !widths_are_same || !left.width.approx_eq(&Figure::default());
 
         if has_border {
+            let left_color = left.color.themed_color(self.theme.unwrap_or_default());
+            let right_color = right.color.themed_color(self.theme.unwrap_or_default());
+            let top_color = top.color.themed_color(self.theme.unwrap_or_default());
+            let bottom_color = bottom.color.themed_color(self.theme.unwrap_or_default());
             let one_rule = widths_are_same
-                && left.color == right.color
-                && top.color == bottom.color
-                && left.color == top.color;
+                && left_color == right_color
+                && top_color == bottom_color
+                && left_color == top_color;
 
             if one_rule {
                 self.with_css_statement(&format!(
                     "border: {:.03}pt solid {}",
                     left.width.get(),
-                    left.color.as_css_string(),
+                    left_color.as_css_string(),
                 ))
             } else {
-                self.with_single_border("left", &left)
-                    .with_single_border("right", &right)
-                    .with_single_border("top", &top)
-                    .with_single_border("bottom", &bottom)
+                self.with_single_border("left", left.width, left_color)
+                    .with_single_border("right", right.width, right_color)
+                    .with_single_border("top", top.width, top_color)
+                    .with_single_border("bottom", bottom.width, bottom_color)
             }
         } else {
             // no border

--- a/frontends/browser/src/utils.rs
+++ b/frontends/browser/src/utils.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use gooey_core::{
-    euclid::{approxeq::ApproxEq, Length},
+    figures::{Approx, Figure},
     styles::{
         border::{Border, BorderOptions},
         style_sheet::{Classes, Rule, State},
@@ -315,7 +315,7 @@ impl CssBlockBuilder {
         let widths_are_same = left.width.approx_eq(&right.width)
             && top.width.approx_eq(&bottom.width)
             && left.width.approx_eq(&top.width);
-        let has_border = !widths_are_same || !left.width.approx_eq(&Length::default());
+        let has_border = !widths_are_same || !left.width.approx_eq(&Figure::default());
 
         if has_border {
             let one_rule = widths_are_same

--- a/frontends/rasterizer/Cargo.toml
+++ b/frontends/rasterizer/Cargo.toml
@@ -20,6 +20,7 @@ image = { version = "0.23", default-features = false, features = [
     "jpeg",
 ] }
 parking_lot = "0.11"
+platforms = { version = "1" }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 winit = { version = "0.25", features = ["web-sys"] }

--- a/frontends/rasterizer/Cargo.toml
+++ b/frontends/rasterizer/Cargo.toml
@@ -24,3 +24,6 @@ platforms = { version = "1" }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 winit = { version = "0.25", features = ["web-sys"] }
+
+[target.'cfg(not(target_arch="wasm32"))'.dependencies]
+winit = { version = "0.25", features = ["x11"] }

--- a/frontends/rasterizer/Cargo.toml
+++ b/frontends/rasterizer/Cargo.toml
@@ -11,10 +11,15 @@ categories = ["gui"]
 readme = "../../README.md"
 
 [dependencies]
-gooey-core = { path="../../core", version="0.1.0-dev.0" }
-gooey-renderer = { path="../../renderer", version="0.1.0-dev.0" }
-winit = { version="0.25", default-features=false }
-image = { version="0.23", default-features=false, features=["ico", "png", "jpeg"] }
+gooey-core = { path = "../../core", version = "0.1.0-dev.0" }
+gooey-renderer = { path = "../../renderer", version = "0.1.0-dev.0" }
+winit = { version = "0.25", default-features = false }
+image = { version = "0.23", default-features = false, features = [
+    "ico",
+    "png",
+    "jpeg",
+] }
+parking_lot = "0.11"
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-winit = { version="0.25", features=["web-sys"] }
+winit = { version = "0.25", features = ["web-sys"] }

--- a/frontends/rasterizer/src/events.rs
+++ b/frontends/rasterizer/src/events.rs
@@ -1,7 +1,7 @@
 use gooey_core::{
     figures::{Point, Scale},
     styles::SystemTheme,
-    Pixels, Points,
+    Pixels, Scaled,
 };
 use winit::event::{
     ElementState, ModifiersState, MouseButton, MouseScrollDelta, ScanCode, TouchPhase,
@@ -24,7 +24,7 @@ pub enum InputEvent {
     },
     /// Mouse cursor event
     MouseMoved {
-        position: Option<Point<f32, Points>>,
+        position: Option<Point<f32, Scaled>>,
     },
     /// Mouse wheel event
     MouseWheel {
@@ -46,7 +46,7 @@ pub enum WindowEvent {
 impl WindowEvent {
     pub fn from_winit_event(
         value: WinitWindowEvent<'_>,
-        scale: Scale<f32, Points, Pixels>,
+        scale: Scale<f32, Scaled, Pixels>,
     ) -> Result<Self, WinitWindowEvent<'_>> {
         match value {
             WinitWindowEvent::ReceivedCharacter(c) => Ok(Self::ReceiveCharacter(c)),

--- a/frontends/rasterizer/src/events.rs
+++ b/frontends/rasterizer/src/events.rs
@@ -1,5 +1,5 @@
 use gooey_core::{
-    euclid::{Point2D, Scale},
+    figures::{Point, Scale},
     styles::SystemTheme,
     Pixels, Points,
 };
@@ -24,7 +24,7 @@ pub enum InputEvent {
     },
     /// Mouse cursor event
     MouseMoved {
-        position: Option<Point2D<f32, Points>>,
+        position: Option<Point<f32, Points>>,
     },
     /// Mouse wheel event
     MouseWheel {
@@ -62,7 +62,7 @@ impl WindowEvent {
             WinitWindowEvent::CursorMoved { position, .. } => {
                 Ok(Self::Input(InputEvent::MouseMoved {
                     position: Some(
-                        Point2D::<f64, Pixels>::new(position.x, position.y).to_f32() / scale,
+                        Point::<f64, Pixels>::new(position.x, position.y).cast::<f32>() / scale,
                     ),
                 }))
             }

--- a/frontends/rasterizer/src/lib.rs
+++ b/frontends/rasterizer/src/lib.rs
@@ -276,12 +276,7 @@ impl<R: Renderer> Rasterizer<R> {
         for (button, handler) in self.state.mouse_button_handlers() {
             self.state.widget_area(&handler).and_then(|bounds| {
                 self.with_transmogrifier(&handler, |transmogrifier, mut context| {
-                    transmogrifier.mouse_drag(
-                        &mut context,
-                        button,
-                        position - bounds.location.to_vector(),
-                        &bounds,
-                    );
+                    transmogrifier.mouse_drag(&mut context, button, position, &bounds);
                 })
             });
         }
@@ -320,13 +315,13 @@ impl<R: Renderer> Rasterizer<R> {
                 if let Some(bounds) = self.state.widget_area(&hovered) {
                     let handled = self
                         .with_transmogrifier(&hovered, |transmogrifier, mut context| {
-                            let position = last_mouse_position - bounds.location.to_vector();
-                            let hit = transmogrifier.hit_test(&mut context, position, &bounds);
+                            let hit =
+                                transmogrifier.hit_test(&mut context, last_mouse_position, &bounds);
                             let handled = hit
                                 && transmogrifier.mouse_down(
                                     &mut context,
                                     button,
-                                    position,
+                                    last_mouse_position,
                                     &bounds,
                                 ) == EventStatus::Processed;
                             if handled {
@@ -357,9 +352,7 @@ impl<R: Renderer> Rasterizer<R> {
                         transmogrifier.mouse_up(
                             &mut context,
                             button,
-                            self.state
-                                .last_mouse_position()
-                                .map(|pos| pos - bounds.location.to_vector()),
+                            self.state.last_mouse_position(),
                             &bounds,
                         );
                         EventResult::processed()

--- a/frontends/rasterizer/src/lib.rs
+++ b/frontends/rasterizer/src/lib.rs
@@ -23,7 +23,7 @@ use std::{collections::HashSet, sync::Arc};
 use events::{InputEvent, WindowEvent};
 use gooey_core::{
     assets::{self, Configuration, Image},
-    figures::{Point, SizedRect},
+    figures::{Point, Rect},
     styles::{
         style_sheet::{self},
         Style, SystemTheme,
@@ -182,13 +182,13 @@ impl<R: Renderer> Rasterizer<R> {
         .with_transmogrifier(self.ui.root_widget().id(), |transmogrifier, mut context| {
             transmogrifier.render_within(
                 &mut context,
-                SizedRect::new(Point::default(), size),
+                Rect::sized(Point::default(), size),
                 &Style::default(),
             );
         });
     }
 
-    pub fn clipped_to(&self, clip: SizedRect<f32, Points>) -> Option<Self> {
+    pub fn clipped_to(&self, clip: Rect<f32, Points>) -> Option<Self> {
         self.renderer().map(|renderer| Self {
             ui: self.ui.clone(),
             state: self.state.clone(),

--- a/frontends/rasterizer/src/lib.rs
+++ b/frontends/rasterizer/src/lib.rs
@@ -28,7 +28,7 @@ use gooey_core::{
         style_sheet::{self},
         Style, SystemTheme,
     },
-    AnyTransmogrifierContext, Callback, Gooey, Points, TransmogrifierContext, WidgetId,
+    AnyTransmogrifierContext, Callback, Gooey, Scaled, TransmogrifierContext, WidgetId,
 };
 use image::{ImageFormat, RgbaImage};
 use winit::event::{
@@ -188,7 +188,7 @@ impl<R: Renderer> Rasterizer<R> {
         });
     }
 
-    pub fn clipped_to(&self, clip: Rect<f32, Points>) -> Option<Self> {
+    pub fn clipped_to(&self, clip: Rect<f32, Scaled>) -> Option<Self> {
         self.renderer().map(|renderer| Self {
             ui: self.ui.clone(),
             state: self.state.clone(),
@@ -231,7 +231,7 @@ impl<R: Renderer> Rasterizer<R> {
         self.state.set_system_theme(theme);
     }
 
-    fn handle_cursor_moved(&self, position: Option<Point<f32, Points>>) -> EventResult {
+    fn handle_cursor_moved(&self, position: Option<Point<f32, Scaled>>) -> EventResult {
         self.state.set_last_mouse_position(position);
         self.invoke_drag_events(position);
         if let Some(position) = position {
@@ -244,7 +244,7 @@ impl<R: Renderer> Rasterizer<R> {
     }
 
     #[allow(clippy::unused_self)] // TODO needs implementing
-    fn invoke_drag_events(&self, _position: Option<Point<f32, Points>>) {}
+    fn invoke_drag_events(&self, _position: Option<Point<f32, Scaled>>) {}
 
     #[allow(clippy::unused_self)] // TODO needs implementing
     fn handle_keyboard_input(
@@ -256,7 +256,7 @@ impl<R: Renderer> Rasterizer<R> {
         EventResult::ignored()
     }
 
-    fn update_hover(&self, position: Point<f32, Points>) -> EventResult {
+    fn update_hover(&self, position: Point<f32, Scaled>) -> EventResult {
         let new_hover = self
             .state
             .widgets_under_point(position)

--- a/frontends/rasterizer/src/lib.rs
+++ b/frontends/rasterizer/src/lib.rs
@@ -23,7 +23,7 @@ use std::{collections::HashSet, sync::Arc};
 use events::{InputEvent, WindowEvent};
 use gooey_core::{
     assets::{self, Configuration, Image},
-    euclid::{Point2D, Rect},
+    figures::{Point, SizedRect},
     styles::{
         style_sheet::{self},
         Style, SystemTheme,
@@ -182,13 +182,13 @@ impl<R: Renderer> Rasterizer<R> {
         .with_transmogrifier(self.ui.root_widget().id(), |transmogrifier, mut context| {
             transmogrifier.render_within(
                 &mut context,
-                Rect::new(Point2D::default(), size),
+                SizedRect::new(Point::default(), size),
                 &Style::default(),
             );
         });
     }
 
-    pub fn clipped_to(&self, clip: Rect<f32, Points>) -> Option<Self> {
+    pub fn clipped_to(&self, clip: SizedRect<f32, Points>) -> Option<Self> {
         self.renderer().map(|renderer| Self {
             ui: self.ui.clone(),
             state: self.state.clone(),
@@ -231,7 +231,7 @@ impl<R: Renderer> Rasterizer<R> {
         self.state.set_system_theme(theme);
     }
 
-    fn handle_cursor_moved(&self, position: Option<Point2D<f32, Points>>) -> EventResult {
+    fn handle_cursor_moved(&self, position: Option<Point<f32, Points>>) -> EventResult {
         self.state.set_last_mouse_position(position);
         self.invoke_drag_events(position);
         if let Some(position) = position {
@@ -244,7 +244,7 @@ impl<R: Renderer> Rasterizer<R> {
     }
 
     #[allow(clippy::unused_self)] // TODO needs implementing
-    fn invoke_drag_events(&self, _position: Option<Point2D<f32, Points>>) {}
+    fn invoke_drag_events(&self, _position: Option<Point<f32, Points>>) {}
 
     #[allow(clippy::unused_self)] // TODO needs implementing
     fn handle_keyboard_input(
@@ -256,7 +256,7 @@ impl<R: Renderer> Rasterizer<R> {
         EventResult::ignored()
     }
 
-    fn update_hover(&self, position: Point2D<f32, Points>) -> EventResult {
+    fn update_hover(&self, position: Point<f32, Points>) -> EventResult {
         let new_hover = self
             .state
             .widgets_under_point(position)

--- a/frontends/rasterizer/src/state.rs
+++ b/frontends/rasterizer/src/state.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use gooey_core::{
-    euclid::Point2D,
+    figures::{Point, Rectlike},
     styles::{style_sheet, SystemTheme},
     Points, WidgetId,
 };
@@ -30,7 +30,7 @@ struct Data {
     focus: Option<WidgetId>,
     active: Option<WidgetId>,
 
-    last_mouse_position: Option<Point2D<f32, Points>>,
+    last_mouse_position: Option<Point<f32, Points>>,
     mouse_button_handlers: HashMap<MouseButton, WidgetId>,
     needs_redraw: bool,
 }
@@ -62,7 +62,7 @@ impl State {
         data.area.get(&widget.id).cloned()
     }
 
-    pub fn widgets_under_point(&self, location: Point2D<f32, Points>) -> Vec<WidgetId> {
+    pub fn widgets_under_point(&self, location: Point<f32, Points>) -> Vec<WidgetId> {
         let data = self.data.lock();
         data.widgets_under_point(location).cloned().collect()
     }
@@ -77,12 +77,12 @@ impl State {
         data.needs_redraw
     }
 
-    pub fn set_last_mouse_position(&self, location: Option<Point2D<f32, Points>>) {
+    pub fn set_last_mouse_position(&self, location: Option<Point<f32, Points>>) {
         let mut data = self.data.lock();
         data.last_mouse_position = location;
     }
 
-    pub fn last_mouse_position(&self) -> Option<Point2D<f32, Points>> {
+    pub fn last_mouse_position(&self) -> Option<Point<f32, Points>> {
         let data = self.data.lock();
         data.last_mouse_position
     }
@@ -214,7 +214,7 @@ impl Data {
 
     pub fn widgets_under_point(
         &self,
-        location: Point2D<f32, Points>,
+        location: Point<f32, Points>,
     ) -> impl Iterator<Item = &WidgetId> {
         self.order
             .iter()

--- a/frontends/rasterizer/src/state.rs
+++ b/frontends/rasterizer/src/state.rs
@@ -7,7 +7,7 @@ use std::{
 use gooey_core::{
     figures::{Point, Rectlike},
     styles::{style_sheet, SystemTheme},
-    Points, WidgetId,
+    Scaled, WidgetId,
 };
 use parking_lot::Mutex;
 use winit::event::MouseButton;
@@ -30,7 +30,7 @@ struct Data {
     focus: Option<WidgetId>,
     active: Option<WidgetId>,
 
-    last_mouse_position: Option<Point<f32, Points>>,
+    last_mouse_position: Option<Point<f32, Scaled>>,
     mouse_button_handlers: HashMap<MouseButton, WidgetId>,
     needs_redraw: bool,
 }
@@ -62,7 +62,7 @@ impl State {
         data.area.get(&widget.id).cloned()
     }
 
-    pub fn widgets_under_point(&self, location: Point<f32, Points>) -> Vec<WidgetId> {
+    pub fn widgets_under_point(&self, location: Point<f32, Scaled>) -> Vec<WidgetId> {
         let data = self.data.lock();
         data.widgets_under_point(location).cloned().collect()
     }
@@ -77,12 +77,12 @@ impl State {
         data.needs_redraw
     }
 
-    pub fn set_last_mouse_position(&self, location: Option<Point<f32, Points>>) {
+    pub fn set_last_mouse_position(&self, location: Option<Point<f32, Scaled>>) {
         let mut data = self.data.lock();
         data.last_mouse_position = location;
     }
 
-    pub fn last_mouse_position(&self) -> Option<Point<f32, Points>> {
+    pub fn last_mouse_position(&self) -> Option<Point<f32, Scaled>> {
         let data = self.data.lock();
         data.last_mouse_position
     }
@@ -214,7 +214,7 @@ impl Data {
 
     pub fn widgets_under_point(
         &self,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
     ) -> impl Iterator<Item = &WidgetId> {
         self.order
             .iter()

--- a/frontends/rasterizer/src/state.rs
+++ b/frontends/rasterizer/src/state.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use gooey_core::{
@@ -9,9 +9,10 @@ use gooey_core::{
     styles::{style_sheet, SystemTheme},
     Points, WidgetId,
 };
+use parking_lot::Mutex;
 use winit::event::MouseButton;
 
-use crate::Configuration;
+use crate::{Configuration, ContentArea};
 
 #[derive(Clone, Default, Debug)]
 pub struct State {
@@ -22,7 +23,7 @@ pub struct State {
 #[derive(Default, Debug)]
 struct Data {
     order: Vec<WidgetId>,
-    bounds: HashMap<u32, Rect<f32, Points>>,
+    area: HashMap<u32, ContentArea>,
     system_theme: SystemTheme,
 
     hover: HashSet<WidgetId>,
@@ -47,57 +48,57 @@ impl State {
     }
 
     pub fn new_frame(&self) {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         data.new_frame();
     }
 
-    pub fn widget_rendered(&self, widget: WidgetId, bounds: Rect<f32, Points>) {
-        let mut data = self.data.lock().unwrap();
-        data.widget_rendered(widget, bounds);
+    pub fn widget_rendered(&self, widget: WidgetId, area: ContentArea) {
+        let mut data = self.data.lock();
+        data.widget_rendered(widget, area);
     }
 
-    pub fn widget_bounds(&self, widget: &WidgetId) -> Option<Rect<f32, Points>> {
-        let data = self.data.lock().unwrap();
-        data.bounds.get(&widget.id).copied()
+    pub fn widget_area(&self, widget: &WidgetId) -> Option<ContentArea> {
+        let data = self.data.lock();
+        data.area.get(&widget.id).cloned()
     }
 
     pub fn widgets_under_point(&self, location: Point2D<f32, Points>) -> Vec<WidgetId> {
-        let data = self.data.lock().unwrap();
+        let data = self.data.lock();
         data.widgets_under_point(location).cloned().collect()
     }
 
     pub fn set_needs_redraw(&self) {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         data.needs_redraw = true;
     }
 
     pub fn needs_redraw(&self) -> bool {
-        let data = self.data.lock().unwrap();
+        let data = self.data.lock();
         data.needs_redraw
     }
 
     pub fn set_last_mouse_position(&self, location: Option<Point2D<f32, Points>>) {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         data.last_mouse_position = location;
     }
 
     pub fn last_mouse_position(&self) -> Option<Point2D<f32, Points>> {
-        let data = self.data.lock().unwrap();
+        let data = self.data.lock();
         data.last_mouse_position
     }
 
     pub fn clear_hover(&self) -> HashSet<WidgetId> {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         std::mem::take(&mut data.hover)
     }
 
     pub fn hover(&self) -> HashSet<WidgetId> {
-        let data = self.data.lock().unwrap();
+        let data = self.data.lock();
         data.hover.clone()
     }
 
     pub fn set_hover(&self, hover: HashSet<WidgetId>) {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         if data.hover != hover {
             data.needs_redraw = true;
             data.hover = hover;
@@ -105,12 +106,12 @@ impl State {
     }
 
     pub fn active(&self) -> Option<WidgetId> {
-        let data = self.data.lock().unwrap();
+        let data = self.data.lock();
         data.active.clone()
     }
 
     pub fn set_active(&self, active: Option<WidgetId>) {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         if data.active != active {
             data.needs_redraw = true;
             data.active = active;
@@ -118,12 +119,12 @@ impl State {
     }
 
     pub fn focus(&self) -> Option<WidgetId> {
-        let data = self.data.lock().unwrap();
+        let data = self.data.lock();
         data.focus.clone()
     }
 
     pub fn set_focus(&self, focus: Option<WidgetId>) {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         if data.focus != focus {
             data.needs_redraw = true;
             data.focus = focus;
@@ -131,7 +132,7 @@ impl State {
     }
 
     pub fn blur(&self) {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         if data.focus.is_some() || data.active.is_some() {
             data.focus = None;
             data.active = None;
@@ -140,12 +141,12 @@ impl State {
     }
 
     pub fn system_theme(&self) -> SystemTheme {
-        let data = self.data.lock().unwrap();
+        let data = self.data.lock();
         data.system_theme
     }
 
     pub fn set_system_theme(&self, system_theme: SystemTheme) {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         if data.system_theme != system_theme {
             data.needs_redraw = true;
             data.system_theme = system_theme;
@@ -153,22 +154,22 @@ impl State {
     }
 
     pub fn register_mouse_handler(&self, button: MouseButton, widget: WidgetId) {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         data.mouse_button_handlers.insert(button, widget);
     }
 
     pub fn take_mouse_button_handler(&self, button: MouseButton) -> Option<WidgetId> {
-        let mut data = self.data.lock().unwrap();
+        let mut data = self.data.lock();
         data.mouse_button_handlers.remove(&button)
     }
 
     pub fn mouse_button_handlers(&self) -> HashMap<MouseButton, WidgetId> {
-        let data = self.data.lock().unwrap();
+        let data = self.data.lock();
         data.mouse_button_handlers.clone()
     }
 
     pub fn ui_state_for(&self, widget_id: &WidgetId) -> style_sheet::State {
-        let data = self.data.lock().unwrap();
+        let data = self.data.lock();
         style_sheet::State {
             hovered: data.hover.contains(widget_id),
             active: data.active.as_ref() == Some(widget_id),
@@ -202,12 +203,12 @@ impl State {
 impl Data {
     pub fn new_frame(&mut self) {
         self.order.clear();
-        self.bounds.clear();
+        self.area.clear();
         self.needs_redraw = false;
     }
 
-    pub fn widget_rendered(&mut self, widget: WidgetId, bounds: Rect<f32, Points>) {
-        self.bounds.insert(widget.id, bounds);
+    pub fn widget_rendered(&mut self, widget: WidgetId, area: ContentArea) {
+        self.area.insert(widget.id, area);
         self.order.push(widget);
     }
 
@@ -215,9 +216,12 @@ impl Data {
         &self,
         location: Point2D<f32, Points>,
     ) -> impl Iterator<Item = &WidgetId> {
-        self.order
-            .iter()
-            .rev()
-            .filter(move |id| self.bounds.get(&id.id).unwrap().contains(location))
+        self.order.iter().rev().filter(move |id| {
+            self.area
+                .get(&id.id)
+                .unwrap()
+                .content_bounds()
+                .contains(location)
+        })
     }
 }

--- a/frontends/rasterizer/src/state.rs
+++ b/frontends/rasterizer/src/state.rs
@@ -216,12 +216,9 @@ impl Data {
         &self,
         location: Point2D<f32, Points>,
     ) -> impl Iterator<Item = &WidgetId> {
-        self.order.iter().rev().filter(move |id| {
-            self.area
-                .get(&id.id)
-                .unwrap()
-                .content_bounds()
-                .contains(location)
-        })
+        self.order
+            .iter()
+            .rev()
+            .filter(move |id| self.area.get(&id.id).unwrap().bounds().contains(location))
     }
 }

--- a/frontends/rasterizer/src/state.rs
+++ b/frontends/rasterizer/src/state.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use gooey_core::{
-    euclid::{Point2D, Rect},
+    euclid::Point2D,
     styles::{style_sheet, SystemTheme},
     Points, WidgetId,
 };

--- a/frontends/rasterizer/src/transmogrifier.rs
+++ b/frontends/rasterizer/src/transmogrifier.rs
@@ -39,7 +39,7 @@ pub trait WidgetRasterizer<R: Renderer>: Transmogrifier<Rasterizer<R>> + Sized +
                 .max(&Size::default());
             let remaining_width = bounds.size - content;
             // TODO support Alignment and VerticalAlignment
-            let location = (remaining_width.to_vector() / 2.).to_point();
+            let location = (remaining_width / 2.).to_point();
 
             let area = ContentArea {
                 location,

--- a/frontends/rasterizer/src/transmogrifier.rs
+++ b/frontends/rasterizer/src/transmogrifier.rs
@@ -3,7 +3,7 @@ use std::{any::TypeId, convert::TryFrom, ops::Deref};
 use gooey_core::{
     figures::{Point, Rect, Rectlike, Size, Vector, Vectorlike},
     styles::{border::Border, BackgroundColor, Padding, Style},
-    AnyTransmogrifier, AnyTransmogrifierContext, AnyWidget, Points, Transmogrifier,
+    AnyTransmogrifier, AnyTransmogrifierContext, AnyWidget, Scaled, Transmogrifier,
     TransmogrifierContext, TransmogrifierState, Widget, WidgetRegistration,
 };
 use gooey_renderer::Renderer;
@@ -19,7 +19,7 @@ pub trait WidgetRasterizer<R: Renderer>: Transmogrifier<Rasterizer<R>> + Sized +
     fn render_within(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        bounds: Rect<f32, Points>,
+        bounds: Rect<f32, Scaled>,
         parent_style: &Style,
     ) {
         if let Some(clipped) = context.frontend.clipped_to(bounds) {
@@ -178,13 +178,13 @@ pub trait WidgetRasterizer<R: Renderer>: Transmogrifier<Rasterizer<R>> + Sized +
     fn measure_content(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
-    ) -> Size<f32, Points>;
+        constraints: Size<Option<f32>, Scaled>,
+    ) -> Size<f32, Scaled>;
 
     fn content_size(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
+        constraints: Size<Option<f32>, Scaled>,
     ) -> ContentSize {
         let effective_style = context
             .frontend
@@ -215,7 +215,7 @@ pub trait WidgetRasterizer<R: Renderer>: Transmogrifier<Rasterizer<R>> + Sized +
     fn hit_test(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) -> bool {
         true
@@ -231,7 +231,7 @@ pub trait WidgetRasterizer<R: Renderer>: Transmogrifier<Rasterizer<R>> + Sized +
     fn mouse_move(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) -> bool {
         self.hit_test(context, location, area)
@@ -242,7 +242,7 @@ pub trait WidgetRasterizer<R: Renderer>: Transmogrifier<Rasterizer<R>> + Sized +
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         button: MouseButton,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) -> EventStatus {
         EventStatus::Ignored
@@ -253,7 +253,7 @@ pub trait WidgetRasterizer<R: Renderer>: Transmogrifier<Rasterizer<R>> + Sized +
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         button: MouseButton,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) {
     }
@@ -263,7 +263,7 @@ pub trait WidgetRasterizer<R: Renderer>: Transmogrifier<Rasterizer<R>> + Sized +
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         button: MouseButton,
-        location: Option<Point<f32, Points>>,
+        location: Option<Point<f32, Scaled>>,
         area: &ContentArea,
     ) {
     }
@@ -273,7 +273,7 @@ pub trait AnyWidgetRasterizer<R: Renderer>: AnyTransmogrifier<Rasterizer<R>> + S
     fn render_within(
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
-        bounds: Rect<f32, Points>,
+        bounds: Rect<f32, Scaled>,
         parent_style: &Style,
     );
 
@@ -288,19 +288,19 @@ pub trait AnyWidgetRasterizer<R: Renderer>: AnyTransmogrifier<Rasterizer<R>> + S
     fn measure_content(
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
-    ) -> Size<f32, Points>;
+        constraints: Size<Option<f32>, Scaled>,
+    ) -> Size<f32, Scaled>;
 
     fn content_size(
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
+        constraints: Size<Option<f32>, Scaled>,
     ) -> ContentSize;
 
     fn hit_test(
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) -> bool;
 
@@ -311,7 +311,7 @@ pub trait AnyWidgetRasterizer<R: Renderer>: AnyTransmogrifier<Rasterizer<R>> + S
     fn mouse_move(
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) -> bool;
 
@@ -319,7 +319,7 @@ pub trait AnyWidgetRasterizer<R: Renderer>: AnyTransmogrifier<Rasterizer<R>> + S
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
         button: MouseButton,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) -> EventStatus;
 
@@ -327,7 +327,7 @@ pub trait AnyWidgetRasterizer<R: Renderer>: AnyTransmogrifier<Rasterizer<R>> + S
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
         button: MouseButton,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     );
 
@@ -335,7 +335,7 @@ pub trait AnyWidgetRasterizer<R: Renderer>: AnyTransmogrifier<Rasterizer<R>> + S
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
         button: MouseButton,
-        location: Option<Point<f32, Points>>,
+        location: Option<Point<f32, Scaled>>,
         area: &ContentArea,
     );
 }
@@ -348,7 +348,7 @@ where
     fn render_within(
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
-        bounds: Rect<f32, Points>,
+        bounds: Rect<f32, Scaled>,
         parent_style: &Style,
     ) {
         <Self as WidgetRasterizer<R>>::render_within(
@@ -378,8 +378,8 @@ where
     fn measure_content(
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
-    ) -> Size<f32, Points> {
+        constraints: Size<Option<f32>, Scaled>,
+    ) -> Size<f32, Scaled> {
         <Self as WidgetRasterizer<R>>::measure_content(
             self,
             &mut TransmogrifierContext::try_from(context).unwrap(),
@@ -390,7 +390,7 @@ where
     fn content_size(
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
+        constraints: Size<Option<f32>, Scaled>,
     ) -> ContentSize {
         <Self as WidgetRasterizer<R>>::content_size(
             self,
@@ -402,7 +402,7 @@ where
     fn hit_test(
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) -> bool {
         <Self as WidgetRasterizer<R>>::hit_test(
@@ -430,7 +430,7 @@ where
     fn mouse_move(
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) -> bool {
         <Self as WidgetRasterizer<R>>::mouse_move(
@@ -445,7 +445,7 @@ where
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
         button: MouseButton,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) -> EventStatus {
         <Self as WidgetRasterizer<R>>::mouse_down(
@@ -461,7 +461,7 @@ where
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
         button: MouseButton,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) {
         <Self as WidgetRasterizer<R>>::mouse_drag(
@@ -477,7 +477,7 @@ where
         &self,
         context: &mut AnyTransmogrifierContext<'_, Rasterizer<R>>,
         button: MouseButton,
-        location: Option<Point<f32, Points>>,
+        location: Option<Point<f32, Scaled>>,
         area: &ContentArea,
     ) {
         <Self as WidgetRasterizer<R>>::mouse_up(
@@ -539,14 +539,14 @@ pub enum EventStatus {
 
 #[derive(Default, Debug, Clone)]
 pub struct ContentSize {
-    pub content: Size<f32, Points>,
+    pub content: Size<f32, Scaled>,
     pub padding: Padding,
     pub border: Border,
 }
 
 impl ContentSize {
     #[must_use]
-    pub fn total_size(&self) -> Size<f32, Points> {
+    pub fn total_size(&self) -> Size<f32, Scaled> {
         self.content + self.padding.minimum_size() + self.border.minimum_size()
     }
 }
@@ -554,12 +554,12 @@ impl ContentSize {
 #[derive(Default, Debug, Clone)]
 #[must_use]
 pub struct ContentArea {
-    pub location: Point<f32, Points>,
+    pub location: Point<f32, Scaled>,
     pub size: ContentSize,
 }
 
 impl ContentArea {
-    pub fn sized(size: Size<f32, Points>) -> Self {
+    pub fn sized(size: Size<f32, Scaled>) -> Self {
         Self {
             location: Point::default(),
             size: ContentSize {
@@ -572,13 +572,13 @@ impl ContentArea {
 
     /// Returns the bounds of the content area.
     #[must_use]
-    pub fn content_bounds(&self) -> Rect<f32, Points> {
+    pub fn content_bounds(&self) -> Rect<f32, Scaled> {
         Rect::sized(self.location, self.size.content)
     }
 
     /// Returns the entire area including padding and border.
     #[must_use]
-    pub fn bounds(&self) -> Rect<f32, Points> {
+    pub fn bounds(&self) -> Rect<f32, Scaled> {
         Rect::sized(
             self.location
                 - Vector::new(
@@ -591,7 +591,7 @@ impl ContentArea {
         )
     }
 
-    pub fn translate(&self, by: Vector<f32, Points>) -> Self {
+    pub fn translate(&self, by: Vector<f32, Scaled>) -> Self {
         Self {
             location: self.location + by,
             size: self.size.clone(),

--- a/frontends/rasterizer/src/transmogrifier.rs
+++ b/frontends/rasterizer/src/transmogrifier.rs
@@ -22,7 +22,7 @@ pub trait WidgetRasterizer<R: Renderer>: Transmogrifier<Rasterizer<R>> + Sized +
         bounds: Rect<f32, Points>,
         parent_style: &Style,
     ) {
-        if let Some(rasterizer) = context.frontend.clipped_to(bounds) {
+        if let Some(clipped) = context.frontend.clipped_to(bounds) {
             let effective_style = context
                 .frontend
                 .ui
@@ -48,12 +48,12 @@ pub trait WidgetRasterizer<R: Renderer>: Transmogrifier<Rasterizer<R>> + Sized +
                     border,
                 },
             };
-            rasterizer.rasterized_widget(
-                context.registration.id().clone(),
-                area.translate(bounds.origin.to_vector()),
-            );
 
-            self.render_within_content_area(context, &rasterizer, &area, &effective_style);
+            self.render_within_content_area(context, &clipped, &area, &effective_style);
+            clipped.rasterized_widget(
+                context.registration.id().clone(),
+                area.translate(clipped.renderer().unwrap().clip_bounds().origin.to_vector()),
+            );
         }
     }
 
@@ -529,7 +529,7 @@ pub enum EventStatus {
     Processed,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct ContentSize {
     pub content: Size2D<f32, Points>,
     pub padding: Padding,
@@ -543,7 +543,7 @@ impl ContentSize {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 #[must_use]
 pub struct ContentArea {
     pub location: Point2D<f32, Points>,

--- a/gooey/Cargo.toml
+++ b/gooey/Cargo.toml
@@ -41,31 +41,32 @@ name = "widget-explorer"
 test = true
 
 [dependencies]
-gooey-rasterizer = { path="../frontends/rasterizer", version="0.1.0-dev.0", optional=true }
-gooey-browser = { path="../frontends/browser", version="0.1.0-dev.0", optional=true }
-gooey-renderer = { path="../renderer", version="0.1.0-dev.0" }
-gooey-text = { path="../text", version="0.1.0-dev.0" }
-gooey-core = { path="../core", version="0.1.0-dev.0" }
-gooey-widgets = { path="../widgets", version="0.1.0-dev.0" }
+gooey-rasterizer = { path = "../frontends/rasterizer", version = "0.1.0-dev.0", optional = true }
+gooey-browser = { path = "../frontends/browser", version = "0.1.0-dev.0", optional = true }
+gooey-renderer = { path = "../renderer", version = "0.1.0-dev.0" }
+gooey-text = { path = "../text", version = "0.1.0-dev.0" }
+gooey-core = { path = "../core", version = "0.1.0-dev.0" }
+gooey-widgets = { path = "../widgets", version = "0.1.0-dev.0" }
 cfg-if = "1"
-platforms = { version="1", optional=true }
-image = { version="0.23", default-features=false, optional=true }
-png = { git="https://github.com/image-rs/image-png.git", optional=true }
+platforms = { version = "1", optional = true }
+image = { version = "0.23", default-features = false, optional = true }
+png = { git = "https://github.com/image-rs/image-png.git", optional = true }
 thiserror = "1"
-tempfile = { version="3", optional=true }
+tempfile = { version = "3", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-futures = { version="0.4", optional=true }
-wasm-bindgen = { version="0.2" }
-web-sys = { version="0.3", features=["Window"] }
+wasm-bindgen-futures = { version = "0.4", optional = true }
+wasm-bindgen = { version = "0.2" }
+web-sys = { version = "0.3", features = ["Window"] }
 flume = "0.10"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version="1", features=["full"], optional=true }
-gooey-kludgine = { path="../frontends/renderers/kludgine", version="0.1.0-dev.0", optional=true }
+tokio = { version = "1", features = ["full"], optional = true }
+gooey-kludgine = { path = "../frontends/renderers/kludgine", version = "0.1.0-dev.0", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version="1", features=["full"] }
+tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 wasm-bindgen = "0.2"
+log = "0.4"

--- a/gooey/examples/basic.rs
+++ b/gooey/examples/basic.rs
@@ -76,7 +76,7 @@ mod tests {
 
     use gooey::{
         core::{
-            euclid::{Point2D, Size2D},
+            figures::{Point, Size},
             styles::SystemTheme,
         },
         HeadlessError,
@@ -89,11 +89,11 @@ mod tests {
     async fn demo() -> Result<(), HeadlessError> {
         for theme in [SystemTheme::Dark, SystemTheme::Light] {
             let mut headless = app().headless();
-            let mut recorder = headless.begin_recording(Size2D::new(320, 240), theme, true, 30);
-            recorder.set_cursor(Point2D::new(100., 200.));
+            let mut recorder = headless.begin_recording(Size::new(320, 240), theme, true, 30);
+            recorder.set_cursor(Point::new(100., 200.));
             recorder.render_frame(Duration::from_millis(100)).await?;
             recorder
-                .move_cursor_to(Point2D::new(160., 130.), Duration::from_millis(300))
+                .move_cursor_to(Point::new(160., 130.), Duration::from_millis(300))
                 .await?;
             recorder.pause(Duration::from_millis(250));
             recorder.left_click().await?;
@@ -114,7 +114,7 @@ mod tests {
             );
 
             recorder
-                .move_cursor_to(Point2D::new(200., 180.), Duration::from_millis(300))
+                .move_cursor_to(Point::new(200., 180.), Duration::from_millis(300))
                 .await?;
             recorder.pause(Duration::from_millis(1000));
 

--- a/gooey/examples/checkbox.rs
+++ b/gooey/examples/checkbox.rs
@@ -79,7 +79,7 @@ mod tests {
 
     use gooey::{
         core::{
-            euclid::{Point2D, Size2D},
+            figures::{Point, Size},
             styles::SystemTheme,
         },
         HeadlessError,
@@ -92,11 +92,11 @@ mod tests {
     async fn demo() -> Result<(), HeadlessError> {
         for theme in [SystemTheme::Dark, SystemTheme::Light] {
             let mut headless = app().headless();
-            let mut recorder = headless.begin_recording(Size2D::new(320, 240), theme, true, 30);
-            recorder.set_cursor(Point2D::new(100., 200.));
+            let mut recorder = headless.begin_recording(Size::new(320, 240), theme, true, 30);
+            recorder.set_cursor(Point::new(100., 200.));
             recorder.render_frame(Duration::from_millis(100)).await?;
             recorder
-                .move_cursor_to(Point2D::new(160., 120.), Duration::from_millis(300))
+                .move_cursor_to(Point::new(160., 120.), Duration::from_millis(300))
                 .await?;
             recorder.left_click().await?;
 
@@ -114,11 +114,11 @@ mod tests {
 
             // Wiggle the cursor to make the second click seem like a click.
             recorder
-                .move_cursor_to(Point2D::new(150., 140.), Duration::from_millis(100))
+                .move_cursor_to(Point::new(150., 140.), Duration::from_millis(100))
                 .await?;
             recorder.pause(Duration::from_millis(00));
             recorder
-                .move_cursor_to(Point2D::new(160., 120.), Duration::from_millis(200))
+                .move_cursor_to(Point::new(160., 120.), Duration::from_millis(200))
                 .await?;
 
             recorder.left_click().await?;
@@ -136,7 +136,7 @@ mod tests {
                 .unwrap());
 
             recorder
-                .move_cursor_to(Point2D::new(200., 180.), Duration::from_millis(300))
+                .move_cursor_to(Point::new(200., 180.), Duration::from_millis(300))
                 .await?;
             recorder.pause(Duration::from_millis(1000));
 

--- a/gooey/examples/layout.rs
+++ b/gooey/examples/layout.rs
@@ -1,6 +1,6 @@
 use gooey::{
     core::{
-        euclid::Length,
+        figures::Figure,
         styles::{Alignment, FontSize, VerticalAlignment},
         Context, DefaultWidget, StyledWidget,
     },
@@ -44,7 +44,7 @@ impl Behavior for Counter {
                 None,
                 Button::new("Click Me!", events.map(|_| CounterEvent::ButtonClicked)),
                 WidgetLayout::build()
-                    .left(Dimension::Exact(Length::new(0.)))
+                    .left(Dimension::Exact(Figure::new(0.)))
                     .top(Dimension::Percent(0.4))
                     .height(Dimension::Percent(0.2))
                     .width(Dimension::Percent(0.5))
@@ -57,7 +57,7 @@ impl Behavior for Counter {
                     .with(Alignment::Center)
                     .with(VerticalAlignment::Center),
                 WidgetLayout::build()
-                    .right(Dimension::Exact(Length::new(0.)))
+                    .right(Dimension::Exact(Figure::new(0.)))
                     .top(Dimension::Percent(0.4))
                     .height(Dimension::Percent(0.2))
                     .width(Dimension::Percent(0.5))
@@ -100,7 +100,7 @@ mod tests {
 
     use gooey::{
         core::{
-            euclid::{Point2D, Size2D},
+            figures::{Point, Size},
             styles::SystemTheme,
         },
         HeadlessError,
@@ -113,11 +113,11 @@ mod tests {
     async fn demo() -> Result<(), HeadlessError> {
         for theme in [SystemTheme::Dark, SystemTheme::Light] {
             let mut headless = app().headless();
-            let mut recorder = headless.begin_recording(Size2D::new(320, 240), theme, true, 30);
-            recorder.set_cursor(Point2D::new(100., 200.));
+            let mut recorder = headless.begin_recording(Size::new(320, 240), theme, true, 30);
+            recorder.set_cursor(Point::new(100., 200.));
             recorder.render_frame(Duration::from_millis(100)).await?;
             recorder
-                .move_cursor_to(Point2D::new(80., 120.), Duration::from_millis(300))
+                .move_cursor_to(Point::new(80., 120.), Duration::from_millis(300))
                 .await?;
 
             for i in 1_u32..5 {
@@ -133,7 +133,7 @@ mod tests {
             }
 
             recorder
-                .move_cursor_to(Point2D::new(200., 180.), Duration::from_millis(300))
+                .move_cursor_to(Point::new(200., 180.), Duration::from_millis(300))
                 .await?;
             recorder.pause(Duration::from_millis(1000));
 

--- a/gooey/examples/widget-explorer.rs
+++ b/gooey/examples/widget-explorer.rs
@@ -3,7 +3,7 @@ use gooey_widgets::navigator::Navigator;
 
 mod widget_explorer_screens;
 
-use widget_explorer_screens::{borders, main_menu::MainMenu, navigator, InfoPage, Page};
+use widget_explorer_screens::{borders, input, main_menu::MainMenu, navigator, InfoPage, Page};
 
 #[cfg(test)]
 mod harness;
@@ -15,6 +15,7 @@ fn app() -> App {
         .with_component::<MainMenu>()
         .with_component::<navigator::Demo>()
         .with_component::<borders::Demo>()
+        .with_component::<input::Demo>()
 }
 
 fn main() {

--- a/gooey/examples/widget_explorer_screens/borders.rs
+++ b/gooey/examples/widget_explorer_screens/borders.rs
@@ -10,6 +10,7 @@ use gooey::{
         layout::{Dimension, Layout, WidgetLayout},
     },
 };
+use gooey_core::styles::ColorPair;
 
 #[derive(Debug, Default)]
 pub struct Demo {}
@@ -31,13 +32,18 @@ impl Behavior for Demo {
         _events: &EventMapper<Self>,
     ) -> gooey_core::StyledWidget<Self::Content> {
         let border_only = Container::new(
-            centered_label("Only Borders")
-                .with(Border::uniform(BorderOptions::new(2., Color::RED))),
+            centered_label("Only Borders").with(Border::uniform(BorderOptions::new(
+                2.,
+                ColorPair::from(Color::RED),
+            ))),
             builder.storage(),
         );
         let with_padding = Container::new(
             centered_label("With Padding")
-                .with(Border::uniform(BorderOptions::new(2., Color::RED)))
+                .with(Border::uniform(BorderOptions::new(
+                    2.,
+                    ColorPair::from(Color::RED),
+                )))
                 .with(Padding::uniform(10.)),
             builder.storage(),
         );

--- a/gooey/examples/widget_explorer_screens/borders.rs
+++ b/gooey/examples/widget_explorer_screens/borders.rs
@@ -91,26 +91,26 @@ impl Behavior for Demo {
 mod tests {
 
     use gooey::HeadlessError;
-    use gooey_core::{euclid::Size2D, styles::SystemTheme};
+    use gooey_core::{figures::Size, styles::SystemTheme};
 
     #[cfg(not(target_arch = "wasm32-unknown-unknown"))]
     #[tokio::test]
     async fn demo() -> Result<(), HeadlessError> {
-        use gooey_core::euclid::Point2D;
+        use gooey_core::figures::Point;
 
         for theme in [SystemTheme::Dark, SystemTheme::Light] {
             let mut headless = crate::app().headless();
 
             // This isn't an interactive recorder. For the events to work, the widgets positions must be known, but they aren't known until the first render.
             headless
-                .screenshot(Size2D::new(480, 320), theme, None)
+                .screenshot(Size::new(480, 320), theme, None)
                 .await?;
 
-            headless.set_cursor(Point2D::new(300., 300.));
+            headless.set_cursor(Point::new(300., 300.));
             headless.left_click();
 
             headless
-                .screenshot(Size2D::new(480, 320), theme, None)
+                .screenshot(Size::new(480, 320), theme, None)
                 .await?
                 .to_rgb8()
                 .save(crate::harness::snapshot_path(

--- a/gooey/examples/widget_explorer_screens/input.rs
+++ b/gooey/examples/widget_explorer_screens/input.rs
@@ -1,0 +1,58 @@
+use gooey::{
+    core::styles::{Alignment, VerticalAlignment},
+    widgets::{
+        component::{Behavior, Content, EventMapper},
+        input::Input,
+        label::Label,
+        layout::{Dimension, Layout, WidgetLayout},
+    },
+};
+
+#[derive(Debug, Default)]
+pub struct Demo {}
+
+impl Behavior for Demo {
+    type Content = Layout;
+    type Event = ();
+    type Widgets = ();
+
+    fn build_content(
+        &mut self,
+        builder: <Self::Content as Content<Self>>::Builder,
+        _events: &EventMapper<Self>,
+    ) -> gooey_core::StyledWidget<Self::Content> {
+        builder
+            .with(
+                None,
+                Label::new(
+                    "This is a text input widget demo. You can try typing in the field. Copy and \
+                     paste should also work correctly.",
+                )
+                .with(Alignment::Center)
+                .with(VerticalAlignment::Top),
+                WidgetLayout::build()
+                    .top(Dimension::exact(16.))
+                    .fill_width()
+                    .bottom(Dimension::exact(50.))
+                    .finish(),
+            )
+            .with(
+                None,
+                Input::build().value("Lorem Ipsum").finish(),
+                WidgetLayout::build()
+                    .left(Dimension::percent(0.))
+                    .width(Dimension::percent(1.))
+                    .bottom(Dimension::percent(0.25))
+                    .height(Dimension::percent(0.25))
+                    .finish(),
+            )
+            .finish()
+    }
+
+    fn receive_event(
+        _component: &mut gooey_widgets::component::Component<Self>,
+        _event: Self::Event,
+        _context: &gooey_core::Context<gooey_widgets::component::Component<Self>>,
+    ) {
+    }
+}

--- a/gooey/examples/widget_explorer_screens/input.rs
+++ b/gooey/examples/widget_explorer_screens/input.rs
@@ -33,17 +33,16 @@ impl Behavior for Demo {
                 WidgetLayout::build()
                     .top(Dimension::exact(16.))
                     .fill_width()
-                    .bottom(Dimension::exact(50.))
+                    .bottom(Dimension::percent(50.))
                     .finish(),
             )
             .with(
                 None,
                 Input::build().value("Lorem Ipsum").finish(),
                 WidgetLayout::build()
-                    .left(Dimension::percent(0.))
-                    .width(Dimension::percent(1.))
+                    .left(Dimension::percent(0.1))
+                    .width(Dimension::percent(0.8))
                     .bottom(Dimension::percent(0.25))
-                    .height(Dimension::percent(0.25))
                     .finish(),
             )
             .finish()

--- a/gooey/examples/widget_explorer_screens/main_menu.rs
+++ b/gooey/examples/widget_explorer_screens/main_menu.rs
@@ -24,7 +24,7 @@ impl MainMenu {
     pub fn new(navigator: WeakWidgetRegistration) -> Self {
         Self {
             navigator,
-            buttons: vec![Page::Navigator { level: 0 }, Page::Borders],
+            buttons: vec![Page::Navigator { level: 0 }, Page::Borders, Page::Input],
         }
     }
 }

--- a/gooey/examples/widget_explorer_screens/main_menu.rs
+++ b/gooey/examples/widget_explorer_screens/main_menu.rs
@@ -51,8 +51,7 @@ impl Behavior for MainMenu {
             .with(VerticalAlignment::Center),
             WidgetLayout::build()
                 .top(Dimension::zero())
-                .right(Dimension::zero())
-                .left(Dimension::zero())
+                .fill_width()
                 .height(Dimension::percent(0.8))
                 .finish(),
         );

--- a/gooey/examples/widget_explorer_screens/mod.rs
+++ b/gooey/examples/widget_explorer_screens/mod.rs
@@ -17,6 +17,7 @@ use gooey::{
 use crate::widget_explorer_screens::main_menu::MainMenu;
 
 pub mod borders;
+pub mod input;
 pub mod main_menu;
 pub mod navigator;
 
@@ -25,6 +26,7 @@ pub enum Page {
     MainMenu,
     Navigator { level: usize },
     Borders,
+    Input,
 }
 
 impl Default for Page {
@@ -47,6 +49,7 @@ impl Location for Page {
                 }
             }
             Page::Borders => Cow::from("Borders"),
+            Page::Input => Cow::from("Text Input"),
         }
     }
 
@@ -62,6 +65,7 @@ impl Location for Page {
                 storage,
             )),
             Page::Borders => storage.register(Component::new(borders::Demo::default(), storage)),
+            Page::Input => storage.register(Component::new(input::Demo::default(), storage)),
         }
     }
 }

--- a/gooey/examples/widget_explorer_screens/navigator.rs
+++ b/gooey/examples/widget_explorer_screens/navigator.rs
@@ -144,7 +144,7 @@ mod tests {
 
     use gooey::HeadlessError;
     use gooey_core::{
-        euclid::{Point2D, Size2D},
+        figures::{Point, Size},
         styles::SystemTheme,
     };
     use gooey_widgets::navigator::Navigator;
@@ -156,12 +156,12 @@ mod tests {
     async fn demo() -> Result<(), HeadlessError> {
         for theme in [SystemTheme::Dark, SystemTheme::Light] {
             let mut headless = crate::app().headless();
-            let mut recorder = headless.begin_recording(Size2D::new(480, 320), theme, true, 15);
-            recorder.set_cursor(Point2D::new(100., 200.));
+            let mut recorder = headless.begin_recording(Size::new(480, 320), theme, true, 15);
+            recorder.set_cursor(Point::new(100., 200.));
 
             // Open the navigator demo
             recorder
-                .move_cursor_to(Point2D::new(150., 300.), Duration::from_millis(300))
+                .move_cursor_to(Point::new(150., 300.), Duration::from_millis(300))
                 .await?;
             recorder.left_click().await?;
             recorder.pause(Duration::from_millis(500));
@@ -172,7 +172,7 @@ mod tests {
 
             // Go back
             recorder
-                .move_cursor_to(Point2D::new(30., 30.), Duration::from_millis(300))
+                .move_cursor_to(Point::new(30., 30.), Duration::from_millis(300))
                 .await?;
             recorder.left_click().await?;
             recorder.pause(Duration::from_millis(300));
@@ -183,7 +183,7 @@ mod tests {
 
             // Enter back into the navigator demo
             recorder
-                .move_cursor_to(Point2D::new(150., 300.), Duration::from_millis(300))
+                .move_cursor_to(Point::new(150., 300.), Duration::from_millis(300))
                 .await?;
             recorder.left_click().await?;
             recorder.pause(Duration::from_millis(500));
@@ -191,10 +191,7 @@ mod tests {
             // Push a few entries
             for i in 1_u8..3 {
                 recorder
-                    .move_cursor_to(
-                        Point2D::new(130. + i as f32, 290.),
-                        Duration::from_millis(10),
-                    )
+                    .move_cursor_to(Point::new(130. + i as f32, 290.), Duration::from_millis(10))
                     .await?;
                 recorder.left_click().await?;
                 recorder.pause(Duration::from_millis(100));
@@ -214,7 +211,7 @@ mod tests {
 
             // Replace the top
             recorder
-                .move_cursor_to(Point2D::new(240., 290.), Duration::from_millis(10))
+                .move_cursor_to(Point::new(240., 290.), Duration::from_millis(10))
                 .await?;
             recorder.left_click().await?;
             recorder.pause(Duration::from_millis(500));
@@ -233,7 +230,7 @@ mod tests {
 
             // Go home
             recorder
-                .move_cursor_to(Point2D::new(420., 290.), Duration::from_millis(300))
+                .move_cursor_to(Point::new(420., 290.), Duration::from_millis(300))
                 .await?;
             recorder.left_click().await?;
             recorder.pause(Duration::from_millis(1000));

--- a/gooey/src/headless.rs
+++ b/gooey/src/headless.rs
@@ -9,16 +9,14 @@ use std::{
 use gooey_core::{
     figures::{Angle, Point, Size, Vectorlike},
     styles::SystemTheme,
-    Context, Frontend, Pixels, Points, Widget,
+    Context, Frontend, Pixels, Scaled, Widget,
 };
 use gooey_kludgine::{
     kludgine::{
         self,
         core::{
             easygpu::{self, wgpu},
-            flume,
-            math::Scaled,
-            FrameRenderer,
+            flume, FrameRenderer,
         },
         prelude::{ElementState, Fill, MouseButton, Scene, Shape, Stroke, Target},
     },
@@ -55,7 +53,7 @@ impl<R: Renderer> Headless<Rasterizer<R>> {
     }
 
     /// Sets the location of the cursor to `position`. Does not render any frames.
-    pub fn set_cursor(&mut self, position: Point<f32, Points>) {
+    pub fn set_cursor(&mut self, position: Point<f32, Scaled>) {
         self.simulate_event(WindowEvent::Input(InputEvent::MouseMoved {
             position: Some(position),
         }));
@@ -114,7 +112,7 @@ impl Headless<Rasterizer<Kludgine>> {
         &self,
         size: Size<u32, Pixels>,
         theme: SystemTheme,
-        cursor: Option<Point<f32, Points>>,
+        cursor: Option<Point<f32, Scaled>>,
     ) -> Result<DynamicImage, HeadlessError> {
         let (scene_sender, scene_receiver) = flume::unbounded();
 
@@ -201,7 +199,7 @@ pub struct Recorder<'a> {
     theme: SystemTheme,
     render_cursor: bool,
     fps: u16,
-    cursor: Option<Point<f32, Points>>,
+    cursor: Option<Point<f32, Scaled>>,
 }
 
 struct RecordedFrame {
@@ -307,7 +305,7 @@ impl<'a> Recorder<'a> {
     )]
     pub async fn move_cursor_to(
         &mut self,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         duration: Duration,
     ) -> Result<(), HeadlessError> {
         let duration = duration.as_secs_f32();

--- a/gooey/src/headless.rs
+++ b/gooey/src/headless.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use gooey_core::{
-    euclid::{Angle, Point2D, Rotation2D, Size2D},
+    figures::{Angle, Point, Size, Vectorlike},
     styles::SystemTheme,
     Context, Frontend, Pixels, Points, Widget,
 };
@@ -16,7 +16,9 @@ use gooey_kludgine::{
         self,
         core::{
             easygpu::{self, wgpu},
-            flume, FrameRenderer,
+            flume,
+            math::Scaled,
+            FrameRenderer,
         },
         prelude::{ElementState, Fill, MouseButton, Scene, Shape, Stroke, Target},
     },
@@ -53,7 +55,7 @@ impl<R: Renderer> Headless<Rasterizer<R>> {
     }
 
     /// Sets the location of the cursor to `position`. Does not render any frames.
-    pub fn set_cursor(&mut self, position: Point2D<f32, Points>) {
+    pub fn set_cursor(&mut self, position: Point<f32, Points>) {
         self.simulate_event(WindowEvent::Input(InputEvent::MouseMoved {
             position: Some(position),
         }));
@@ -110,9 +112,9 @@ impl Headless<Rasterizer<Kludgine>> {
     /// Returns any errors that arise during the rendering process.
     pub async fn screenshot(
         &self,
-        size: Size2D<u32, Pixels>,
+        size: Size<u32, Pixels>,
         theme: SystemTheme,
-        cursor: Option<Point2D<f32, Points>>,
+        cursor: Option<Point<f32, Points>>,
     ) -> Result<DynamicImage, HeadlessError> {
         let (scene_sender, scene_receiver) = flume::unbounded();
 
@@ -144,23 +146,18 @@ impl Headless<Rasterizer<Kludgine>> {
             const CURSOR_LENGTH: f32 = 16.;
             const INNER_LENGTH: f32 = 14.;
             const TAIL_LENGTH: f32 = 20.;
-            let left_edge_lower = Point2D::new(0., CURSOR_LENGTH);
-            let right_edge_lower =
-                Rotation2D::new(Angle::degrees(-45.)).transform_point(left_edge_lower);
+            let left_edge_lower = Point::new(0., CURSOR_LENGTH);
+            let right_edge_lower = Angle::Degrees(-45.).transform_point(left_edge_lower);
             let left_inner =
-                Rotation2D::new(Angle::degrees(-17.5))
-                    .transform_point(Point2D::<f32, Points>::new(0., INNER_LENGTH));
+                Angle::Degrees(-17.5).transform_point(Point::<f32, Scaled>::new(0., INNER_LENGTH));
             let right_inner =
-                Rotation2D::new(Angle::degrees(-27.5))
-                    .transform_point(Point2D::<f32, Points>::new(0., INNER_LENGTH));
+                Angle::Degrees(-27.5).transform_point(Point::<f32, Scaled>::new(0., INNER_LENGTH));
             let left_tail =
-                Rotation2D::new(Angle::degrees(-17.5))
-                    .transform_point(Point2D::<f32, Points>::new(0., TAIL_LENGTH));
+                Angle::Degrees(-17.5).transform_point(Point::<f32, Scaled>::new(0., TAIL_LENGTH));
             let right_tail =
-                Rotation2D::new(Angle::degrees(-27.5))
-                    .transform_point(Point2D::<f32, Points>::new(0., TAIL_LENGTH));
+                Angle::Degrees(-27.5).transform_point(Point::<f32, Scaled>::new(0., TAIL_LENGTH));
             Shape::polygon(vec![
-                Point2D::default(),
+                Point::default(),
                 left_edge_lower,
                 left_inner,
                 left_tail,
@@ -187,7 +184,7 @@ impl Headless<Rasterizer<Kludgine>> {
     /// Begins a recording session that generates an animation.
     pub fn begin_recording(
         &mut self,
-        size: Size2D<u32, Pixels>,
+        size: Size<u32, Pixels>,
         theme: SystemTheme,
         render_cursor: bool,
         fps: u16,
@@ -200,11 +197,11 @@ impl Headless<Rasterizer<Kludgine>> {
 pub struct Recorder<'a> {
     headless: &'a mut Headless<Rasterizer<Kludgine>>,
     frames: Vec<RecordedFrame>,
-    size: Size2D<u32, Pixels>,
+    size: Size<u32, Pixels>,
     theme: SystemTheme,
     render_cursor: bool,
     fps: u16,
-    cursor: Option<Point2D<f32, Points>>,
+    cursor: Option<Point<f32, Points>>,
 }
 
 struct RecordedFrame {
@@ -228,7 +225,7 @@ impl<'a> DerefMut for Recorder<'a> {
 
 impl<'a> Recorder<'a> {
     fn new(
-        size: Size2D<u32, Pixels>,
+        size: Size<u32, Pixels>,
         theme: SystemTheme,
         render_cursor: bool,
         fps: u16,
@@ -310,13 +307,13 @@ impl<'a> Recorder<'a> {
     )]
     pub async fn move_cursor_to(
         &mut self,
-        location: Point2D<f32, Points>,
+        location: Point<f32, Points>,
         duration: Duration,
     ) -> Result<(), HeadlessError> {
         let duration = duration.as_secs_f32();
         let frames = (duration * f32::from(self.fps)).floor().max(1.);
         let frame_duration = Duration::from_secs_f32(duration / frames);
-        let origin = self.cursor.unwrap_or_else(|| Point2D::new(-16., -16.));
+        let origin = self.cursor.unwrap_or_else(|| Point::new(-16., -16.));
         let step = (location.to_vector() - origin.to_vector()) / frames;
         for frame in 1..=frames as u32 {
             self.simulate_event(WindowEvent::Input(InputEvent::MouseMoved {

--- a/gooey/src/kludgine.rs
+++ b/gooey/src/kludgine.rs
@@ -163,7 +163,7 @@ impl Window for GooeyWindow {
             },
             Event::MouseButton { button, state } => GooeyInputEvent::MouseButton { button, state },
             Event::MouseMoved { position } => GooeyInputEvent::MouseMoved {
-                position: position.map(Point::cast_unit),
+                position: position.map(|p| p.cast_unit()),
             },
             Event::MouseWheel { delta, touch_phase } => {
                 GooeyInputEvent::MouseWheel { delta, touch_phase }

--- a/gooey/src/kludgine.rs
+++ b/gooey/src/kludgine.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, process::Command};
 
 use gooey_core::{assets::Configuration, StyledWidget};
-use gooey_rasterizer::winit::window::Theme;
+use gooey_rasterizer::winit::{event::ModifiersState, window::Theme};
 use platforms::target::{OS, TARGET_OS};
 
 use crate::{
@@ -127,11 +127,13 @@ impl Window for GooeyWindow {
         Ok(())
     }
 
-    fn render(&mut self, scene: &Target) -> kludgine::Result<()> {
+    fn render(&mut self, scene: &Target, status: &mut RedrawStatus) -> kludgine::Result<()> {
         self.ui.render(Kludgine::from(scene));
         self.ui.gooey().process_widget_messages(&self.ui);
         if self.ui.needs_redraw() {
-            self.redrawer.as_ref().unwrap().request_redraw();
+            status.set_needs_redraw();
+        } else if let Some(duration) = self.ui.duration_until_next_redraw() {
+            status.estimate_next_frame(duration);
         }
 
         Ok(())
@@ -141,6 +143,8 @@ impl Window for GooeyWindow {
         self.ui.gooey().process_widget_messages(&self.ui);
         if self.ui.needs_redraw() {
             status.set_needs_redraw();
+        } else if let Some(duration) = self.ui.duration_until_next_redraw() {
+            status.estimate_next_frame(duration);
         }
 
         Ok(())
@@ -150,17 +154,40 @@ impl Window for GooeyWindow {
         &mut self,
         input: InputEvent,
         status: &mut RedrawStatus,
+        scene: &Target,
     ) -> kludgine::Result<()> {
         let input = match input.event {
             Event::Keyboard {
                 scancode,
                 key,
                 state,
-            } => GooeyInputEvent::Keyboard {
-                scancode,
-                key,
-                state,
-            },
+            } => {
+                // When a keyboard event happens, refresh the modifiers.
+                let mut modifiers = ModifiersState::default();
+                let scene_modifiers = scene.modifiers_pressed();
+                if scene_modifiers.alt {
+                    modifiers |= ModifiersState::ALT;
+                }
+                if scene_modifiers.control {
+                    modifiers |= ModifiersState::CTRL;
+                }
+                if scene_modifiers.operating_system {
+                    modifiers |= ModifiersState::LOGO;
+                }
+                if scene_modifiers.shift {
+                    modifiers |= ModifiersState::SHIFT;
+                }
+                self.ui.handle_event(
+                    gooey_rasterizer::events::WindowEvent::ModifiersChanged(modifiers),
+                    Kludgine::from(scene),
+                );
+
+                GooeyInputEvent::Keyboard {
+                    scancode,
+                    key,
+                    state,
+                }
+            }
             Event::MouseButton { button, state } => GooeyInputEvent::MouseButton { button, state },
             Event::MouseMoved { position } => GooeyInputEvent::MouseMoved {
                 position: position.map(|p| p.cast_unit()),
@@ -169,9 +196,30 @@ impl Window for GooeyWindow {
                 GooeyInputEvent::MouseWheel { delta, touch_phase }
             }
         };
-        let result = self
-            .ui
-            .handle_event(gooey_rasterizer::events::WindowEvent::Input(input));
+        let result = self.ui.handle_event(
+            gooey_rasterizer::events::WindowEvent::Input(input),
+            Kludgine::from(scene),
+        );
+        self.ui.gooey().process_widget_messages(&self.ui);
+        if result.needs_redraw || self.ui.needs_redraw() {
+            status.set_needs_redraw();
+        }
+        Ok(())
+    }
+
+    fn receive_character(
+        &mut self,
+        character: char,
+        status: &mut RedrawStatus,
+        scene: &Target,
+    ) -> kludgine::app::Result<()>
+    where
+        Self: Sized,
+    {
+        let result = self.ui.handle_event(
+            gooey_rasterizer::events::WindowEvent::ReceiveCharacter(character),
+            Kludgine::from(scene),
+        );
         self.ui.gooey().process_widget_messages(&self.ui);
         if result.needs_redraw || self.ui.needs_redraw() {
             status.set_needs_redraw();

--- a/gooey/src/style.rs
+++ b/gooey/src/style.rs
@@ -131,6 +131,10 @@ pub fn default_stylesheet() -> StyleSheet {
         }))
         .with(Rule::for_widget::<Input>().with_styles(|style| {
             style
+                .with(BackgroundColor(ColorPair {
+                    light_color: Color::WHITE,
+                    dark_color: Color::BLACK,
+                }))
                 .with(ForegroundColor(ColorPair {
                     light_color: Color::BLACK,
                     dark_color: Color::gray(0.8),

--- a/gooey/src/style.rs
+++ b/gooey/src/style.rs
@@ -1,5 +1,5 @@
 use gooey_core::{
-    euclid::Length,
+    figures::Figure,
     styles::{
         style_sheet::{Rule, StyleSheet},
         Alignment, BackgroundColor, Color, ColorPair, ForegroundColor, Padding, Surround,
@@ -78,7 +78,7 @@ pub fn default_stylesheet() -> StyleSheet {
             style
                 .with(Alignment::Center)
                 .with(VerticalAlignment::Center)
-                .with(Padding(Surround::from(Some(Length::new(5.)))))
+                .with(Padding(Surround::from(Some(Figure::new(5.)))))
         }))
         .with(Rule::for_widget::<Checkbox>().with_styles(|style| {
             style

--- a/gooey/src/style.rs
+++ b/gooey/src/style.rs
@@ -2,14 +2,15 @@ use gooey_core::{
     figures::Figure,
     styles::{
         style_sheet::{Rule, StyleSheet},
-        Alignment, BackgroundColor, Color, ColorPair, ForegroundColor, Padding, Surround,
-        VerticalAlignment,
+        Alignment, BackgroundColor, Border, BorderOptions, Color, ColorPair, ForegroundColor,
+        Padding, Surround, VerticalAlignment,
     },
     ROOT_CLASS, SOLID_WIDGET_CLASS,
 };
 use gooey_widgets::{
     button::{Button, ButtonColor},
     checkbox::Checkbox,
+    input::Input,
     label::Label,
 };
 
@@ -128,4 +129,32 @@ pub fn default_stylesheet() -> StyleSheet {
                 dark_color: Color::gray(0.9),
             }))
         }))
+        .with(Rule::for_widget::<Input>().with_styles(|style| {
+            style
+                .with(ForegroundColor(ColorPair {
+                    light_color: Color::BLACK,
+                    dark_color: Color::gray(0.8),
+                }))
+                .with(Border::uniform(BorderOptions::new(
+                    1.,
+                    ColorPair {
+                        light_color: Color::gray(0.5),
+                        dark_color: Color::gray(0.1),
+                    },
+                )))
+                .with(Padding(Surround::from(Some(Figure::new(5.)))))
+        }))
+        .with(
+            Rule::for_widget::<Input>()
+                .when_focused()
+                .with_styles(|style| {
+                    style.with(Border::uniform(BorderOptions::new(
+                        1.,
+                        ColorPair {
+                            light_color: Color::RED,
+                            dark_color: Color::RED,
+                        },
+                    )))
+                }),
+        )
 }

--- a/integrated-examples/bonsaidb/counter/server/src/main.rs
+++ b/integrated-examples/bonsaidb/counter/server/src/main.rs
@@ -71,7 +71,7 @@ impl GetCounterHandler for ApiDispatcher {
     /// Returns the current counter value.
     async fn handle(&self, _permissions: &actionable::Permissions) -> anyhow::Result<Response> {
         println!("Returning current counter value.");
-        let db = self.server.database::<()>("counter").await.unwrap();
+        let db = self.server.database::<()>(DATABASE_NAME).await.unwrap();
 
         let value = db
             .get_key("count")
@@ -87,7 +87,7 @@ impl GetCounterHandler for ApiDispatcher {
 impl IncrementCounterHandler for ApiDispatcher {
     /// Increments the counter, and publishes a message with the new value.
     async fn handle(&self, _permissions: &actionable::Permissions) -> anyhow::Result<Response> {
-        let db = self.server.database::<()>("counter").await?;
+        let db = self.server.database::<()>(DATABASE_NAME).await?;
 
         let new_value = db.increment_key_by("count", 1_u64).await?;
         self.server

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 
 use gooey_core::{
     assets::Image,
-    euclid::{Length, Point2D, Rect, Scale, Size2D},
+    figures::{Figure, Point, Scale, Size, SizedRect},
     styles::{
         Color, ColorPair, FallbackComponent, FontFamily, FontSize, ForegroundColor, LineWidth,
         Style, SystemTheme,
@@ -26,37 +26,37 @@ use gooey_core::{
 /// Implements drawing APIs.
 pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     /// The size of the area being drawn.
-    fn size(&self) -> Size2D<f32, Points>;
+    fn size(&self) -> Size<f32, Points>;
 
     /// Returns the current system theme.
     fn theme(&self) -> SystemTheme;
 
-    /// A [`Rect`] representing the area being drawn. Due to how rendering
+    /// A [`SizedRect`] representing the area being drawn. Due to how rendering
     /// works, the origin is always zero.
-    fn bounds(&self) -> Rect<f32, Points> {
-        Rect::new(Point2D::default(), self.size())
+    fn bounds(&self) -> SizedRect<f32, Points> {
+        SizedRect::new(Point::default(), self.size())
     }
 
     /// Returns a new renderer instance with the state such that each operation
     /// executes as if the origin is `bounds.origin`. The returned instance's
     /// `size()` should equal `bounds.size`.
-    fn clip_to(&self, bounds: Rect<f32, Points>) -> Self;
+    fn clip_to(&self, bounds: SizedRect<f32, Points>) -> Self;
 
-    /// A [`Rect`] representing the area being drawn. This rect should be offset
+    /// A [`SizedRect`] representing the area being drawn. This rect should be offset
     /// relative to the origin of the renderer.
-    fn clip_bounds(&self) -> Rect<f32, Points>;
+    fn clip_bounds(&self) -> SizedRect<f32, Points>;
 
     /// The scale when converting between [`Points`] and [`Pixels`].
     fn scale(&self) -> Scale<f32, Points, Pixels>;
 
     /// Renders `text` at `baseline_origin` with `options`.
-    fn render_text(&self, text: &str, baseline_origin: Point2D<f32, Points>, options: &TextOptions);
+    fn render_text(&self, text: &str, baseline_origin: Point<f32, Points>, options: &TextOptions);
 
     /// Renders `text` at `baseline_origin` with `options`.
     fn render_text_with_style<F: FallbackComponent<Value = ColorPair>>(
         &self,
         text: &str,
-        baseline_origin: Point2D<f32, Points>,
+        baseline_origin: Point<f32, Points>,
         style: &Style,
     ) {
         self.render_text(
@@ -78,12 +78,12 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     }
 
     /// Fills `rect` using `color`.
-    fn fill_rect(&self, rect: &Rect<f32, Points>, color: Color);
+    fn fill_rect(&self, rect: &SizedRect<f32, Points>, color: Color);
 
     /// Fills `rect` using `style`.
     fn fill_rect_with_style<F: FallbackComponent<Value = ColorPair>>(
         &self,
-        rect: &Rect<f32, Points>,
+        rect: &SizedRect<f32, Points>,
         style: &Style,
     ) {
         self.fill_rect(
@@ -97,12 +97,12 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     }
 
     /// Strokes the outline of `rect` using `options`.
-    fn stroke_rect(&self, rect: &Rect<f32, Points>, options: &StrokeOptions);
+    fn stroke_rect(&self, rect: &SizedRect<f32, Points>, options: &StrokeOptions);
 
     /// Strokes the outline of `rect` using `style`.
     fn stroke_rect_with_style<F: FallbackComponent<Value = ColorPair>>(
         &self,
-        rect: &Rect<f32, Points>,
+        rect: &SizedRect<f32, Points>,
         style: &Style,
     ) {
         self.stroke_rect(rect, &StrokeOptions::from_style::<F>(style, self.theme()));
@@ -111,16 +111,16 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     /// Draws a line between `point_a` and `point_b` using `options`.
     fn stroke_line(
         &self,
-        point_a: Point2D<f32, Points>,
-        point_b: Point2D<f32, Points>,
+        point_a: Point<f32, Points>,
+        point_b: Point<f32, Points>,
         options: &StrokeOptions,
     );
 
     /// Draws a line between `point_a` and `point_b` using `style`.
     fn stroke_line_with_style<F: FallbackComponent<Value = ColorPair>>(
         &self,
-        point_a: Point2D<f32, Points>,
-        point_b: Point2D<f32, Points>,
+        point_a: Point<f32, Points>,
+        point_b: Point<f32, Points>,
         style: &Style,
     ) {
         self.stroke_line(
@@ -131,7 +131,7 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     }
 
     /// Draws an `image` at `location`.
-    fn draw_image(&self, image: &Image, location: Point2D<f32, Points>);
+    fn draw_image(&self, image: &Image, location: Point<f32, Points>);
 }
 
 /// Text rendering and measurement options.
@@ -140,7 +140,7 @@ pub struct TextOptions {
     /// The font family to use.
     pub font_family: Option<String>,
     /// The text size, in [`Points`].
-    pub text_size: Length<f32, Points>,
+    pub text_size: Figure<f32, Points>,
     /// The color to render.
     pub color: Color,
 }
@@ -187,7 +187,7 @@ impl Default for TextOptions {
     fn default() -> Self {
         Self {
             font_family: None,
-            text_size: Length::new(13.),
+            text_size: Figure::new(13.),
             color: Color::default(),
         }
     }
@@ -209,7 +209,7 @@ impl TextOptionsBuilder {
 
     /// Sets the text size to `size_in_points`.
     pub fn text_size(mut self, size_in_points: f32) -> Self {
-        self.options.text_size = Length::new(size_in_points);
+        self.options.text_size = Figure::new(size_in_points);
         self
     }
 
@@ -231,14 +231,14 @@ pub struct StrokeOptions {
     /// The color to stroke.
     pub color: Color,
     /// The width of each line segment.
-    pub line_width: Length<f32, Points>,
+    pub line_width: Figure<f32, Points>,
 }
 
 impl Default for StrokeOptions {
     fn default() -> Self {
         Self {
             color: Color::BLACK,
-            line_width: Length::new(1.),
+            line_width: Figure::new(1.),
         }
     }
 }
@@ -280,7 +280,7 @@ pub struct StrokeOptionsBuilder {
 impl StrokeOptionsBuilder {
     /// Sets the width of the line stroked to `width_in_points`.
     pub fn line_width(mut self, width_in_points: f32) -> Self {
-        self.options.line_width = Length::new(width_in_points);
+        self.options.line_width = Figure::new(width_in_points);
         self
     }
 
@@ -301,20 +301,20 @@ impl StrokeOptionsBuilder {
 #[must_use]
 pub struct TextMetrics<U> {
     /// The width of the text.
-    pub width: Length<f32, U>,
+    pub width: Figure<f32, U>,
     /// The height above the baseline.
-    pub ascent: Length<f32, U>,
+    pub ascent: Figure<f32, U>,
     /// The height below the baseline. Typically a negative number.
-    pub descent: Length<f32, U>,
+    pub descent: Figure<f32, U>,
     /// The spacing expected between lines of text.
-    pub line_gap: Length<f32, U>,
+    pub line_gap: Figure<f32, U>,
 }
 
 impl<U> TextMetrics<U> {
     /// The height of the rendered text. This is computed by combining
     /// [`ascent`](TextMetrics::ascent) and [`descent`](TextMetrics::descent).
     #[must_use]
-    pub fn height(&self) -> Length<f32, U> {
+    pub fn height(&self) -> Figure<f32, U> {
         self.ascent - self.descent
     }
 
@@ -322,7 +322,7 @@ impl<U> TextMetrics<U> {
     /// [`height()`](TextMetrics::height) and
     /// [`line_gap`](TextMetrics::line_gap)
     #[must_use]
-    pub fn line_height(&self) -> Length<f32, U> {
+    pub fn line_height(&self) -> Figure<f32, U> {
         self.height() + self.line_gap
     }
 }

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -15,48 +15,48 @@ use std::fmt::Debug;
 
 use gooey_core::{
     assets::Image,
-    figures::{Figure, Point, Rect, Scale, Size},
+    figures::{DisplayScale, Displayable, Figure, Point, Points, Rect, Scale, Size},
     styles::{
         Color, ColorPair, FallbackComponent, FontFamily, FontSize, ForegroundColor, LineWidth,
         Style, SystemTheme,
     },
-    Pixels, Points,
+    Pixels, Scaled,
 };
 
 /// Implements drawing APIs.
 pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     /// The size of the area being drawn.
-    fn size(&self) -> Size<f32, Points>;
+    fn size(&self) -> Size<f32, Scaled>;
 
     /// Returns the current system theme.
     fn theme(&self) -> SystemTheme;
 
     /// A [`SizedRect`] representing the area being drawn. Due to how rendering
     /// works, the origin is always zero.
-    fn bounds(&self) -> Rect<f32, Points> {
+    fn bounds(&self) -> Rect<f32, Scaled> {
         Rect::sized(Point::default(), self.size())
     }
 
     /// Returns a new renderer instance with the state such that each operation
     /// executes as if the origin is `bounds.origin`. The returned instance's
     /// `size()` should equal `bounds.size`.
-    fn clip_to(&self, bounds: Rect<f32, Points>) -> Self;
+    fn clip_to(&self, bounds: Rect<f32, Scaled>) -> Self;
 
     /// A [`SizedRect`] representing the area being drawn. This rect should be offset
     /// relative to the origin of the renderer.
-    fn clip_bounds(&self) -> Rect<f32, Points>;
+    fn clip_bounds(&self) -> Rect<f32, Scaled>;
 
-    /// The scale when converting between [`Points`] and [`Pixels`].
-    fn scale(&self) -> Scale<f32, Points, Pixels>;
+    /// The scaling factors to use when rendering.
+    fn scale(&self) -> DisplayScale<f32>;
 
     /// Renders `text` at `baseline_origin` with `options`.
-    fn render_text(&self, text: &str, baseline_origin: Point<f32, Points>, options: &TextOptions);
+    fn render_text(&self, text: &str, baseline_origin: Point<f32, Scaled>, options: &TextOptions);
 
     /// Renders `text` at `baseline_origin` with `options`.
     fn render_text_with_style<F: FallbackComponent<Value = ColorPair>>(
         &self,
         text: &str,
-        baseline_origin: Point<f32, Points>,
+        baseline_origin: Point<f32, Scaled>,
         style: &Style,
     ) {
         self.render_text(
@@ -67,10 +67,10 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     }
 
     /// Measures `text` using `options`.
-    fn measure_text(&self, text: &str, options: &TextOptions) -> TextMetrics<Points>;
+    fn measure_text(&self, text: &str, options: &TextOptions) -> TextMetrics<Scaled>;
 
     /// Measures `text` using `style`.
-    fn measure_text_with_style(&self, text: &str, style: &Style) -> TextMetrics<Points> {
+    fn measure_text_with_style(&self, text: &str, style: &Style) -> TextMetrics<Scaled> {
         self.measure_text(
             text,
             &TextOptions::from_style::<ForegroundColor>(style, self.theme()),
@@ -78,12 +78,12 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     }
 
     /// Fills `rect` using `color`.
-    fn fill_rect(&self, rect: &Rect<f32, Points>, color: Color);
+    fn fill_rect(&self, rect: &Rect<f32, Scaled>, color: Color);
 
     /// Fills `rect` using `style`.
     fn fill_rect_with_style<F: FallbackComponent<Value = ColorPair>>(
         &self,
-        rect: &Rect<f32, Points>,
+        rect: &Rect<f32, Scaled>,
         style: &Style,
     ) {
         self.fill_rect(
@@ -97,12 +97,12 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     }
 
     /// Strokes the outline of `rect` using `options`.
-    fn stroke_rect(&self, rect: &Rect<f32, Points>, options: &StrokeOptions);
+    fn stroke_rect(&self, rect: &Rect<f32, Scaled>, options: &StrokeOptions);
 
     /// Strokes the outline of `rect` using `style`.
     fn stroke_rect_with_style<F: FallbackComponent<Value = ColorPair>>(
         &self,
-        rect: &Rect<f32, Points>,
+        rect: &Rect<f32, Scaled>,
         style: &Style,
     ) {
         self.stroke_rect(rect, &StrokeOptions::from_style::<F>(style, self.theme()));
@@ -111,16 +111,16 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     /// Draws a line between `point_a` and `point_b` using `options`.
     fn stroke_line(
         &self,
-        point_a: Point<f32, Points>,
-        point_b: Point<f32, Points>,
+        point_a: Point<f32, Scaled>,
+        point_b: Point<f32, Scaled>,
         options: &StrokeOptions,
     );
 
     /// Draws a line between `point_a` and `point_b` using `style`.
     fn stroke_line_with_style<F: FallbackComponent<Value = ColorPair>>(
         &self,
-        point_a: Point<f32, Points>,
-        point_b: Point<f32, Points>,
+        point_a: Point<f32, Scaled>,
+        point_b: Point<f32, Scaled>,
         style: &Style,
     ) {
         self.stroke_line(
@@ -131,7 +131,7 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     }
 
     /// Draws an `image` at `location`.
-    fn draw_image(&self, image: &Image, location: Point<f32, Points>);
+    fn draw_image(&self, image: &Image, location: Point<f32, Scaled>);
 }
 
 /// Text rendering and measurement options.
@@ -139,8 +139,8 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
 pub struct TextOptions {
     /// The font family to use.
     pub font_family: Option<String>,
-    /// The text size, in [`Points`].
-    pub text_size: Figure<f32, Points>,
+    /// The text size, in [`Scaled`].
+    pub text_size: Figure<f32, Scaled>,
     /// The color to render.
     pub color: Color,
 }
@@ -231,7 +231,7 @@ pub struct StrokeOptions {
     /// The color to stroke.
     pub color: Color,
     /// The width of each line segment.
-    pub line_width: Figure<f32, Points>,
+    pub line_width: Figure<f32, Scaled>,
 }
 
 impl Default for StrokeOptions {
@@ -262,7 +262,7 @@ impl StrokeOptions {
                 .unwrap_or_else(|| ColorPair::from(Color::BLACK))
                 .themed_color(theme),
             line_width: style
-                .get::<LineWidth<Points>>()
+                .get::<LineWidth<Scaled>>()
                 .copied()
                 .unwrap_or_else(|| LineWidth::new(1.))
                 .length(),
@@ -350,5 +350,89 @@ impl<U, V> std::ops::Div<Scale<f32, U, V>> for TextMetrics<V> {
             descent: self.descent / rhs,
             line_gap: self.line_gap / rhs,
         }
+    }
+}
+
+impl Displayable<f32> for TextMetrics<Pixels> {
+    type Pixels = Self;
+    type Points = TextMetrics<Points>;
+    type Scaled = TextMetrics<Scaled>;
+
+    fn to_pixels(&self, _scale: &DisplayScale<f32>) -> Self::Pixels {
+        *self
+    }
+
+    fn to_points(&self, scale: &DisplayScale<f32>) -> Self::Points {
+        TextMetrics {
+            width: self.width.to_points(scale),
+            ascent: self.ascent.to_points(scale),
+            descent: self.descent.to_points(scale),
+            line_gap: self.line_gap.to_points(scale),
+        }
+    }
+
+    fn to_scaled(&self, scale: &DisplayScale<f32>) -> Self::Scaled {
+        TextMetrics {
+            width: self.width.to_scaled(scale),
+            ascent: self.ascent.to_scaled(scale),
+            descent: self.descent.to_scaled(scale),
+            line_gap: self.line_gap.to_scaled(scale),
+        }
+    }
+}
+
+impl Displayable<f32> for TextMetrics<Points> {
+    type Pixels = TextMetrics<Pixels>;
+    type Points = Self;
+    type Scaled = TextMetrics<Scaled>;
+
+    fn to_pixels(&self, scale: &DisplayScale<f32>) -> Self::Pixels {
+        TextMetrics {
+            width: self.width.to_pixels(scale),
+            ascent: self.ascent.to_pixels(scale),
+            descent: self.descent.to_pixels(scale),
+            line_gap: self.line_gap.to_pixels(scale),
+        }
+    }
+
+    fn to_points(&self, _scale: &DisplayScale<f32>) -> Self::Points {
+        *self
+    }
+
+    fn to_scaled(&self, scale: &DisplayScale<f32>) -> Self::Scaled {
+        TextMetrics {
+            width: self.width.to_scaled(scale),
+            ascent: self.ascent.to_scaled(scale),
+            descent: self.descent.to_scaled(scale),
+            line_gap: self.line_gap.to_scaled(scale),
+        }
+    }
+}
+
+impl Displayable<f32> for TextMetrics<Scaled> {
+    type Pixels = TextMetrics<Pixels>;
+    type Points = TextMetrics<Points>;
+    type Scaled = Self;
+
+    fn to_pixels(&self, scale: &DisplayScale<f32>) -> Self::Pixels {
+        TextMetrics {
+            width: self.width.to_pixels(scale),
+            ascent: self.ascent.to_pixels(scale),
+            descent: self.descent.to_pixels(scale),
+            line_gap: self.line_gap.to_pixels(scale),
+        }
+    }
+
+    fn to_points(&self, scale: &DisplayScale<f32>) -> Self::Points {
+        TextMetrics {
+            width: self.width.to_points(scale),
+            ascent: self.ascent.to_points(scale),
+            descent: self.descent.to_points(scale),
+            line_gap: self.line_gap.to_points(scale),
+        }
+    }
+
+    fn to_scaled(&self, _scale: &DisplayScale<f32>) -> Self::Scaled {
+        *self
     }
 }

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -31,7 +31,7 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     /// Returns the current system theme.
     fn theme(&self) -> SystemTheme;
 
-    /// A [`SizedRect`] representing the area being drawn. Due to how rendering
+    /// A [`Rect`] representing the area being drawn. Due to how rendering
     /// works, the origin is always zero.
     fn bounds(&self) -> Rect<f32, Scaled> {
         Rect::sized(Point::default(), self.size())
@@ -42,7 +42,7 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     /// `size()` should equal `bounds.size`.
     fn clip_to(&self, bounds: Rect<f32, Scaled>) -> Self;
 
-    /// A [`SizedRect`] representing the area being drawn. This rect should be offset
+    /// A [`Rect`] representing the area being drawn. This rect should be offset
     /// relative to the origin of the renderer.
     fn clip_bounds(&self) -> Rect<f32, Scaled>;
 

--- a/renderer/src/lib.rs
+++ b/renderer/src/lib.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 
 use gooey_core::{
     assets::Image,
-    figures::{Figure, Point, Scale, Size, SizedRect},
+    figures::{Figure, Point, Rect, Scale, Size},
     styles::{
         Color, ColorPair, FallbackComponent, FontFamily, FontSize, ForegroundColor, LineWidth,
         Style, SystemTheme,
@@ -33,18 +33,18 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
 
     /// A [`SizedRect`] representing the area being drawn. Due to how rendering
     /// works, the origin is always zero.
-    fn bounds(&self) -> SizedRect<f32, Points> {
-        SizedRect::new(Point::default(), self.size())
+    fn bounds(&self) -> Rect<f32, Points> {
+        Rect::sized(Point::default(), self.size())
     }
 
     /// Returns a new renderer instance with the state such that each operation
     /// executes as if the origin is `bounds.origin`. The returned instance's
     /// `size()` should equal `bounds.size`.
-    fn clip_to(&self, bounds: SizedRect<f32, Points>) -> Self;
+    fn clip_to(&self, bounds: Rect<f32, Points>) -> Self;
 
     /// A [`SizedRect`] representing the area being drawn. This rect should be offset
     /// relative to the origin of the renderer.
-    fn clip_bounds(&self) -> SizedRect<f32, Points>;
+    fn clip_bounds(&self) -> Rect<f32, Points>;
 
     /// The scale when converting between [`Points`] and [`Pixels`].
     fn scale(&self) -> Scale<f32, Points, Pixels>;
@@ -78,12 +78,12 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     }
 
     /// Fills `rect` using `color`.
-    fn fill_rect(&self, rect: &SizedRect<f32, Points>, color: Color);
+    fn fill_rect(&self, rect: &Rect<f32, Points>, color: Color);
 
     /// Fills `rect` using `style`.
     fn fill_rect_with_style<F: FallbackComponent<Value = ColorPair>>(
         &self,
-        rect: &SizedRect<f32, Points>,
+        rect: &Rect<f32, Points>,
         style: &Style,
     ) {
         self.fill_rect(
@@ -97,12 +97,12 @@ pub trait Renderer: Debug + Send + Sync + Sized + 'static {
     }
 
     /// Strokes the outline of `rect` using `options`.
-    fn stroke_rect(&self, rect: &SizedRect<f32, Points>, options: &StrokeOptions);
+    fn stroke_rect(&self, rect: &Rect<f32, Points>, options: &StrokeOptions);
 
     /// Strokes the outline of `rect` using `style`.
     fn stroke_rect_with_style<F: FallbackComponent<Value = ColorPair>>(
         &self,
-        rect: &SizedRect<f32, Points>,
+        rect: &Rect<f32, Points>,
         style: &Style,
     ) {
         self.stroke_rect(rect, &StrokeOptions::from_style::<F>(style, self.theme()));

--- a/text/Cargo.toml
+++ b/text/Cargo.toml
@@ -14,3 +14,6 @@ gooey-core = { path = "../core", version = "0.1.0-dev.0" }
 gooey-renderer = { path = "../renderer", version = "0.1.0-dev.0" }
 approx = "0.5"
 parking_lot = "0.11"
+
+[target.'cfg(target_arch="wasm32")'.dependencies]
+parking_lot = { version = "0.11", features = ["wasm-bindgen"] }

--- a/text/Cargo.toml
+++ b/text/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["gui"]
 readme = "../README.md"
 
 [dependencies]
-gooey-core = { path="../core", version="0.1.0-dev.0" }
-gooey-renderer = { path="../renderer", version="0.1.0-dev.0" }
+gooey-core = { path = "../core", version = "0.1.0-dev.0" }
+gooey-renderer = { path = "../renderer", version = "0.1.0-dev.0" }
 approx = "0.5"
+parking_lot = "0.11"

--- a/text/src/lib.rs
+++ b/text/src/lib.rs
@@ -19,7 +19,7 @@ use std::{
 use gooey_core::{
     figures::Point,
     styles::{ColorPair, FallbackComponent, Style},
-    Points,
+    Scaled,
 };
 use gooey_renderer::Renderer;
 use prepared::PreparedText;
@@ -111,7 +111,7 @@ impl Text {
     pub fn render_at<F: FallbackComponent<Value = ColorPair>, R: Renderer>(
         &self,
         renderer: &R,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         wrapping: TextWrap,
         context_style: Option<&Style>,
     ) {
@@ -122,7 +122,7 @@ impl Text {
     pub fn render_baseline_at<F: FallbackComponent<Value = ColorPair>, R: Renderer>(
         &self,
         renderer: &R,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         wrapping: TextWrap,
         context_style: Option<&Style>,
     ) {
@@ -132,7 +132,7 @@ impl Text {
     fn render_core<F: FallbackComponent<Value = ColorPair>, R: Renderer>(
         &self,
         renderer: &R,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         offset_baseline: bool,
         wrapping: TextWrap,
         context_style: Option<&Style>,

--- a/text/src/lib.rs
+++ b/text/src/lib.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 use gooey_core::{
-    euclid::Point2D,
+    figures::Point,
     styles::{ColorPair, FallbackComponent, Style},
     Points,
 };
@@ -111,7 +111,7 @@ impl Text {
     pub fn render_at<F: FallbackComponent<Value = ColorPair>, R: Renderer>(
         &self,
         renderer: &R,
-        location: Point2D<f32, Points>,
+        location: Point<f32, Points>,
         wrapping: TextWrap,
         context_style: Option<&Style>,
     ) {
@@ -122,7 +122,7 @@ impl Text {
     pub fn render_baseline_at<F: FallbackComponent<Value = ColorPair>, R: Renderer>(
         &self,
         renderer: &R,
-        location: Point2D<f32, Points>,
+        location: Point<f32, Points>,
         wrapping: TextWrap,
         context_style: Option<&Style>,
     ) {
@@ -132,7 +132,7 @@ impl Text {
     fn render_core<F: FallbackComponent<Value = ColorPair>, R: Renderer>(
         &self,
         renderer: &R,
-        location: Point2D<f32, Points>,
+        location: Point<f32, Points>,
         offset_baseline: bool,
         wrapping: TextWrap,
         context_style: Option<&Style>,

--- a/text/src/lib.rs
+++ b/text/src/lib.rs
@@ -59,6 +59,10 @@ impl Span {
         &self.text
     }
 
+    pub(crate) fn recache_length(&mut self) {
+        self.length = self.text.chars().count();
+    }
+
     /// The length in characters.
     #[must_use]
     pub fn len(&self) -> usize {
@@ -141,6 +145,7 @@ impl Text {
     pub fn remove_range(&mut self, range: Range<usize>) {
         self.for_each_in_range_mut(range, |span, relative_range| {
             span.text.replace_range(relative_range, "");
+            span.recache_length();
         });
     }
 
@@ -149,6 +154,7 @@ impl Text {
     pub fn insert_str(&mut self, offset: usize, value: &str) {
         self.for_each_in_range_mut(offset..offset + 1, |span, relative_range| {
             span.text.insert_str(relative_range.start, value);
+            span.recache_length();
         });
     }
 

--- a/text/src/lib.rs
+++ b/text/src/lib.rs
@@ -138,7 +138,7 @@ impl Text {
         context_style: Option<&Style>,
     ) {
         let prepared_text = self.wrap(renderer, wrapping, context_style);
-        prepared_text.render::<F, R>(renderer, location, offset_baseline);
+        prepared_text.render::<F, R>(renderer, location, offset_baseline, context_style);
     }
 
     /// Removes text in `range`. Empty spans will be removed.

--- a/text/src/prepared.rs
+++ b/text/src/prepared.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use gooey_core::{
-    figures::{Figure, Point, Size, SizedRect, Vector},
+    figures::{Figure, Point, Rect, Rectlike, Size, Vector},
     styles::{Alignment, ColorPair, FallbackComponent, Style, VerticalAlignment},
     Points,
 };
@@ -89,9 +89,10 @@ impl PreparedText {
     pub fn render_within<F: FallbackComponent<Value = ColorPair>, R: Renderer>(
         &self,
         renderer: &R,
-        bounds: SizedRect<f32, Points>,
+        bounds: Rect<f32, Points>,
         style: &Style,
     ) -> Figure<f32, Points> {
+        let bounds = bounds.as_sized();
         let text_size = self.size();
         let origin_y = match style.get::<VerticalAlignment>() {
             Some(VerticalAlignment::Bottom) => bounds.size.height - text_size.height,

--- a/text/src/prepared.rs
+++ b/text/src/prepared.rs
@@ -23,7 +23,7 @@ impl PreparedText {
             |(width, height), line_size| {
                 (
                     width.max(Figure::new(line_size.width)),
-                    height + Figure::new(line_size.height),
+                    height + line_size.height,
                 )
             },
         );
@@ -43,10 +43,10 @@ impl PreparedText {
                     line.alignment_offset = Figure::default();
                 }
                 Alignment::Center => {
-                    line.alignment_offset = (align_width - Figure::new(line.size().width)) / 2.;
+                    line.alignment_offset = (align_width - line.size().width) / 2.;
                 }
                 Alignment::Right => {
-                    line.alignment_offset = align_width - Figure::new(line.size().width);
+                    line.alignment_offset = align_width - line.size().width;
                 }
             }
         }

--- a/text/src/prepared.rs
+++ b/text/src/prepared.rs
@@ -148,10 +148,16 @@ pub struct PreparedSpan {
 
 impl PreparedSpan {
     /// Returns a new span with `style`, `text`, and `metrics`.
-    pub(crate) fn new(style: Arc<Style>, text: String, metrics: TextMetrics<Points>) -> Self {
+    pub(crate) fn new(
+        style: Arc<Style>,
+        text: String,
+        offset: usize,
+        metrics: TextMetrics<Points>,
+    ) -> Self {
         Self {
             data: Arc::new(PreparedSpanData {
                 location: Length::default(),
+                offset,
                 style,
                 text,
                 metrics,
@@ -185,11 +191,18 @@ impl PreparedSpan {
     pub fn text(&self) -> &str {
         &self.data.text
     }
+
+    /// Returns the offset, in characters, of this span.
+    #[must_use]
+    pub fn offset(&self) -> usize {
+        self.data.offset
+    }
 }
 
 #[derive(Clone, Debug)]
 struct PreparedSpanData {
     location: Length<f32, Points>,
+    offset: usize,
     style: Arc<Style>,
     text: String,
     metrics: TextMetrics<Points>,

--- a/text/src/prepared.rs
+++ b/text/src/prepared.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use gooey_core::{
     figures::{Figure, Point, Rect, Rectlike, Size, Vector},
     styles::{Alignment, ColorPair, FallbackComponent, Style, VerticalAlignment},
-    Points,
+    Scaled,
 };
 use gooey_renderer::{Renderer, TextMetrics};
 
@@ -17,7 +17,7 @@ pub struct PreparedText {
 impl PreparedText {
     /// Returns the total size this text will occupy when rendered.
     #[must_use]
-    pub fn size(&self) -> Size<f32, Points> {
+    pub fn size(&self) -> Size<f32, Scaled> {
         let (width, height) = self.lines.iter().map(PreparedLine::size).fold(
             (Figure::default(), Figure::default()),
             |(width, height), line_size| {
@@ -30,7 +30,7 @@ impl PreparedText {
         Size::from_figures(width, height)
     }
 
-    pub(crate) fn align(&mut self, align_width: Figure<f32, Points>) {
+    pub(crate) fn align(&mut self, align_width: Figure<f32, Scaled>) {
         let mut last_alignment = Alignment::Left;
         for line in &mut self.lines {
             if let Some(span) = line.spans.first() {
@@ -59,9 +59,9 @@ impl PreparedText {
     pub fn render<F: FallbackComponent<Value = ColorPair>, R: Renderer>(
         &self,
         renderer: &R,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         offset_baseline: bool,
-    ) -> Figure<f32, Points> {
+    ) -> Figure<f32, Scaled> {
         let mut current_line_baseline = Figure::new(0.);
 
         for (line_index, line) in self.lines.iter().enumerate() {
@@ -89,9 +89,9 @@ impl PreparedText {
     pub fn render_within<F: FallbackComponent<Value = ColorPair>, R: Renderer>(
         &self,
         renderer: &R,
-        bounds: Rect<f32, Points>,
+        bounds: Rect<f32, Scaled>,
         style: &Style,
-    ) -> Figure<f32, Points> {
+    ) -> Figure<f32, Scaled> {
         let bounds = bounds.as_sized();
         let text_size = self.size();
         let origin_y = match style.get::<VerticalAlignment>() {
@@ -110,16 +110,16 @@ pub struct PreparedLine {
     /// The spans that comprise this line.
     pub spans: Vec<PreparedSpan>,
     /// The metrics of the line as a whole.
-    pub metrics: TextMetrics<Points>,
+    pub metrics: TextMetrics<Scaled>,
     /// The offset of this line for the alignment. When rendering, each span's
     /// location is offset by this amount to account for [`Alignment`].
-    pub alignment_offset: Figure<f32, Points>,
+    pub alignment_offset: Figure<f32, Scaled>,
 }
 
 impl PreparedLine {
     /// The size of the bounding box of this line.
     #[must_use]
-    pub fn size(&self) -> Size<f32, Points> {
+    pub fn size(&self) -> Size<f32, Scaled> {
         if self.spans.is_empty() {
             Size::from_figures(Figure::default(), self.height())
         } else {
@@ -135,7 +135,7 @@ impl PreparedLine {
 
     /// The height of the line.
     #[must_use]
-    pub fn height(&self) -> Figure<f32, Points> {
+    pub fn height(&self) -> Figure<f32, Scaled> {
         self.metrics.line_height()
     }
 }
@@ -153,7 +153,7 @@ impl PreparedSpan {
         style: Arc<Style>,
         text: String,
         offset: usize,
-        metrics: TextMetrics<Points>,
+        metrics: TextMetrics<Scaled>,
     ) -> Self {
         Self {
             data: Arc::new(PreparedSpanData {
@@ -166,18 +166,18 @@ impl PreparedSpan {
         }
     }
 
-    pub(crate) fn set_location(&mut self, location: Figure<f32, Points>) {
+    pub(crate) fn set_location(&mut self, location: Figure<f32, Scaled>) {
         Arc::make_mut(&mut self.data).location = location;
     }
 
     /// Returns the offset within the line of this text. Does not include alignment.
     #[must_use]
-    pub fn location(&self) -> Figure<f32, Points> {
+    pub fn location(&self) -> Figure<f32, Scaled> {
         self.data.location
     }
 
     /// Returns the metrics of this span.
-    pub fn metrics(&self) -> &TextMetrics<Points> {
+    pub fn metrics(&self) -> &TextMetrics<Scaled> {
         &self.data.metrics
     }
 
@@ -202,9 +202,9 @@ impl PreparedSpan {
 
 #[derive(Clone, Debug)]
 struct PreparedSpanData {
-    location: Figure<f32, Points>,
+    location: Figure<f32, Scaled>,
     offset: usize,
     style: Arc<Style>,
     text: String,
-    metrics: TextMetrics<Points>,
+    metrics: TextMetrics<Scaled>,
 }

--- a/text/src/rich.rs
+++ b/text/src/rich.rs
@@ -1,13 +1,14 @@
+use std::{cmp::Ordering, fmt::Display, ops::Range, sync::Arc};
+
+use gooey_core::styles::Style;
 use gooey_renderer::Renderer;
+use parking_lot::Mutex;
 
 use crate::{prepared::PreparedText, wrap::TextWrap, Text};
-use std::{
-    cmp::Ordering,
-    ops::Range,
-    sync::{Arc, Mutex},
-};
 
+/// A multi-paragraph rich text data type.
 #[derive(Debug, Clone, Default)]
+#[must_use]
 pub struct RichText {
     data: Arc<Mutex<RichTextData>>,
 }
@@ -25,58 +26,72 @@ impl Default for RichTextData {
     }
 }
 
+/// Indicates whether a paragraph should be kept or removed.
 pub enum ParagraphRemoval {
+    /// The paragraph should be removed.
     Remove,
+    /// The paragraph should be kept.
     Keep,
 }
 
 impl RichText {
+    /// Creates a new instance with `paragraphs`.
     pub fn new(paragraphs: Vec<Text>) -> Self {
         Self {
             data: Arc::new(Mutex::new(RichTextData { paragraphs })),
         }
     }
 
-    pub async fn remove_range(&self, range: Range<RichTextPosition>) {
-        assert!(range.start <= range.end);
+    /// Removes a range of characters.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `range.end` is less than `range.start`.
+    pub fn remove_range(&self, range: Range<RichTextPosition>) {
+        assert!(range.start < range.end);
 
-        self.for_each_in_range_mut(range.clone(), |text, text_range, paragraph_index| {
-            text.remove_range(text_range);
-            if paragraph_index != range.start.paragraph && paragraph_index != range.end.paragraph {
-                ParagraphRemoval::Remove
-            } else {
-                ParagraphRemoval::Keep
+        if range.start != range.end {
+            self.for_each_in_range_mut(range.clone(), |text, text_range, paragraph_index| {
+                text.remove_range(text_range);
+                if paragraph_index != range.start.paragraph
+                    && paragraph_index != range.end.paragraph
+                {
+                    ParagraphRemoval::Remove
+                } else {
+                    ParagraphRemoval::Keep
+                }
+            });
+
+            // If the range spanned paragraphs, the inner paragraphs will be removed but we need to
+            // merge the first and last paragraphs
+            if range.start.paragraph != range.end.paragraph {
+                let mut data = self.data.lock();
+                let mut paragraph_to_merge = data.paragraphs.remove(range.start.paragraph + 1);
+                data.paragraphs[range.start.paragraph]
+                    .spans
+                    .append(&mut paragraph_to_merge.spans);
             }
-        })
-        .await;
-
-        // If the range spanned paragraphs, the inner paragraphs will be removed but we need to
-        // merge the first and last paragraphs
-        if range.start.paragraph != range.end.paragraph {
-            let mut data = self.data.write().await;
-            let mut paragraph_to_merge = data.paragraphs.remove(range.start.paragraph + 1);
-            data.paragraphs[range.start.paragraph]
-                .spans
-                .append(&mut paragraph_to_merge.spans);
         }
     }
 
-    pub async fn insert_str(&self, location: RichTextPosition, value: &str) {
+    /// Inserts `value` at `location`, preserving the style at the location.
+    pub fn insert_str(&self, location: RichTextPosition, value: &str) {
         self.for_each_in_range_mut(location..location, |text, text_range, _| {
             text.insert_str(text_range.start, value);
 
             ParagraphRemoval::Keep
-        })
-        .await;
+        });
     }
 
-    pub async fn for_each_in_range<F: FnMut(&Text, Range<usize>)>(
+    /// Interates over each paragraph calling `callback` with the paragraph and
+    /// the local character range.
+    pub fn for_each_in_range<F: FnMut(&Text, Range<usize>)>(
         &self,
         range: Range<RichTextPosition>,
         mut callback: F,
     ) {
-        let data = self.data.read().await;
-        for paragraph_index in range.start.paragraph..(range.end.paragraph + 1) {
+        let data = self.data.lock();
+        for paragraph_index in range.start.paragraph..=range.end.paragraph {
             if let Some(paragraph) = data.paragraphs.get(paragraph_index) {
                 let start = if range.start.paragraph == paragraph_index {
                     range.start.offset
@@ -89,22 +104,22 @@ impl RichText {
                     paragraph.len()
                 };
 
-                callback(paragraph, start..end)
+                callback(paragraph, start..end);
             }
         }
     }
 
-    pub async fn for_each_in_range_mut<
-        F: Fn(&mut Text, Range<usize>, usize) -> ParagraphRemoval,
-    >(
+    /// Interates over each paragraph calling `callback` with a mutable
+    /// reference to the paragraph and the local character range.
+    pub fn for_each_in_range_mut<F: Fn(&mut Text, Range<usize>, usize) -> ParagraphRemoval>(
         &self,
         range: Range<RichTextPosition>,
         callback: F,
     ) {
-        let mut data = self.data.write().await;
+        let mut data = self.data.lock();
         let mut paragraphs_to_remove = Vec::new();
 
-        for paragraph_index in range.start.paragraph..(range.end.paragraph + 1) {
+        for paragraph_index in range.start.paragraph..=range.end.paragraph {
             if let Some(paragraph) = data.paragraphs.get_mut(paragraph_index) {
                 let start = if range.start.paragraph == paragraph_index {
                     range.start.offset
@@ -129,21 +144,24 @@ impl RichText {
         // Remove in reverse order to ensure that indexes don't change while removing
         paragraphs_to_remove.reverse();
         for paragraph_index in paragraphs_to_remove {
-            data.paragraphs.remove(paragraph_index);
+            drop(data.paragraphs.remove(paragraph_index));
         }
     }
 
-    pub async fn prepare<R: Renderer>(&self, context: &R, wrapping: TextWrap) -> Vec<PreparedText> {
-        let data = self.data.read().await;
+    /// Prepares the rich text for rendering.
+    pub fn prepare<R: Renderer>(&self, renderer: &R, wrapping: TextWrap) -> Vec<PreparedText> {
+        let data = self.data.lock();
         let mut prepared = Vec::new();
-        for paragraph in data.paragraphs.iter() {
-            prepared.push(paragraph.wrap(context.renderer(), wrapping.clone()).await?);
+        for paragraph in &data.paragraphs {
+            prepared.push(paragraph.wrap(renderer, wrapping, None));
         }
-        Ok(prepared)
+        prepared
     }
 
-    pub async fn position_after(&self, mut position: RichTextPosition) -> RichTextPosition {
-        let data = self.data.read().await;
+    /// Returns the next [`RichTextPosition`] after `position`. Returns the
+    /// passed in location if it's at the end of this text.
+    pub fn position_after(&self, mut position: RichTextPosition) -> RichTextPosition {
+        let data = self.data.lock();
         let next_offset = position.offset + 1;
         if next_offset > data.paragraphs[position.paragraph].len() {
             if data.paragraphs.len() > position.paragraph + 1 {
@@ -155,7 +173,9 @@ impl RichText {
         position
     }
 
-    pub async fn position_before(&self, mut position: RichTextPosition) -> RichTextPosition {
+    /// Returns the previous [`RichTextPosition`] before position. Returns the
+    /// first position if it's at the beginning of this text.
+    pub fn position_before(&self, mut position: RichTextPosition) -> RichTextPosition {
         if position.offset == 0 {
             if position.paragraph > 0 {
                 todo!("Need to support multiple paragraphs")
@@ -167,33 +187,91 @@ impl RichText {
         position
     }
 
-    pub async fn end(&self) -> RichTextPosition {
-        let data = self.data.read().await;
+    /// Returns the last valid location in this text.
+    #[allow(clippy::missing_panics_doc)]
+    pub fn end(&self) -> RichTextPosition {
+        let data = self.data.lock();
         RichTextPosition {
             paragraph: data.paragraphs.len() - 1,
+            // This data structure guarantees at least one paragraph.
             offset: data.paragraphs.last().unwrap().len(),
         }
     }
 
-    pub async fn to_string(&self) -> String {
-        let data = self.data.read().await;
-        let mut paragraphs = Vec::with_capacity(data.paragraphs.len());
-        for paragraph in data.paragraphs.iter() {
-            paragraphs.push(paragraph.to_string());
-        }
-
-        paragraphs.join("\n")
+    /// Returns a clone of the paragraphs contained in this text. To access the
+    /// data without a copy, use [`for_each_in_range`] or
+    /// [`for_each_in_range_mut`].
+    #[must_use]
+    pub fn paragraphs(&self) -> Vec<Text> {
+        let data = self.data.lock();
+        data.paragraphs.clone()
     }
 
-    pub async fn paragraphs(&self) -> Vec<Text> {
-        let data = self.data.read().await;
-        data.paragraphs.clone()
+    /// Returns the character offset of `position` within this text. If the
+    /// position is beyond the bounds of the text, the last character position
+    /// is returned.
+    #[must_use]
+    pub fn character_offset_of(&self, position: RichTextPosition) -> usize {
+        let data = self.data.lock();
+        let mut offset = 0;
+        for (index, paragraph) in data.paragraphs.iter().enumerate() {
+            if index == position.paragraph {
+                offset += position.offset;
+                break;
+            }
+
+            // Add 1 for the end of line.
+            offset += paragraph.len() + 1;
+        }
+
+        offset
+    }
+
+    /// Returns the position of the character `offset` into this text. If the
+    /// character offset is beyond the bounds of this text, the last position is
+    /// returned.
+    pub fn position_of_character(&self, mut offset: usize) -> RichTextPosition {
+        let data = self.data.lock();
+        let mut last_paragraph_len = 0;
+        for (index, paragraph) in data.paragraphs.iter().enumerate() {
+            let paragraph_len = paragraph.len();
+            if paragraph_len >= offset {
+                return RichTextPosition {
+                    paragraph: index,
+                    offset,
+                };
+            }
+
+            // Add 1 for the end of line.
+            offset -= paragraph_len + 1;
+            last_paragraph_len = paragraph_len;
+        }
+
+        RichTextPosition {
+            paragraph: data.paragraphs.len() - 1,
+            offset: last_paragraph_len,
+        }
     }
 }
 
+impl Display for RichText {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let data = self.data.lock();
+        for paragraph in &data.paragraphs {
+            <Text as Display>::fmt(paragraph, f)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A location within a [`RichText`] object.
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+#[must_use]
 pub struct RichTextPosition {
+    /// The paragraph index.
     pub paragraph: usize,
+    /// The character offset within the paragraph.
     pub offset: usize,
 }
 
@@ -212,13 +290,26 @@ impl Ord for RichTextPosition {
     }
 }
 
+impl<'a> From<&'a str> for RichText {
+    fn from(text: &str) -> Self {
+        // TODO handle \r and \r\n. This is doable with Pattern but it's not straightforward because there's no impl of pattern for a callback with a str.
+        Self::new(
+            text.split('\n')
+                .map(|s| Text::span(s, Style::default()))
+                .collect(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use gooey_core::styles::Style;
+
     use super::*;
 
     #[test]
     fn remove_range_one_paragraph_start() {
-        let text = RichText::new(vec![Text::span("a123", Default::default())]);
+        let text = RichText::new(vec![Text::span("a123", Style::default())]);
         text.remove_range(
             RichTextPosition {
                 offset: 0,
@@ -233,7 +324,7 @@ mod tests {
 
     #[test]
     fn remove_range_one_paragraph_end() {
-        let text = RichText::new(vec![Text::span("123a", Default::default())]);
+        let text = RichText::new(vec![Text::span("123a", Style::default())]);
         text.remove_range(
             RichTextPosition {
                 offset: 3,
@@ -248,7 +339,7 @@ mod tests {
 
     #[test]
     fn remove_range_one_paragraph_inner() {
-        let text = RichText::new(vec![Text::span("1a23", Default::default())]);
+        let text = RichText::new(vec![Text::span("1a23", Style::default())]);
         text.remove_range(
             RichTextPosition {
                 offset: 1,
@@ -264,8 +355,8 @@ mod tests {
     #[test]
     fn remove_range_multi_paragraph_cross_boundaries() {
         let text = RichText::new(vec![
-            Text::span("123a", Default::default()),
-            Text::span("b456", Default::default()),
+            Text::span("123a", Style::default()),
+            Text::span("b456", Style::default()),
         ]);
         text.remove_range(
             RichTextPosition {
@@ -282,9 +373,9 @@ mod tests {
     #[test]
     fn remove_range_multi_paragraph_cross_multiple_boundaries() {
         let text = RichText::new(vec![
-            Text::span("123a", Default::default()),
-            Text::span("bc", Default::default()),
-            Text::span("d456", Default::default()),
+            Text::span("123a", Style::default()),
+            Text::span("bc", Style::default()),
+            Text::span("d456", Style::default()),
         ]);
         text.remove_range(
             RichTextPosition {

--- a/text/src/rich.rs
+++ b/text/src/rich.rs
@@ -203,8 +203,8 @@ impl RichText {
     }
 
     /// Returns a clone of the paragraphs contained in this text. To access the
-    /// data without a copy, use [`for_each_in_range`] or
-    /// [`for_each_in_range_mut`].
+    /// data without a copy, use [`Self::for_each_in_range()`] or
+    /// [`Self::for_each_in_range_mut`].
     #[must_use]
     pub fn paragraphs(&self) -> Vec<Text> {
         let data = self.data.lock();

--- a/text/src/rich.rs
+++ b/text/src/rich.rs
@@ -164,8 +164,10 @@ impl RichText {
         let data = self.data.lock();
         let next_offset = position.offset + 1;
         if next_offset > data.paragraphs[position.paragraph].len() {
-            if data.paragraphs.len() > position.paragraph + 1 {
-                todo!("Need to support multiple paragraphs")
+            let next_paragraph = position.paragraph + 1;
+            if next_paragraph < data.paragraphs.len() {
+                position.paragraph = next_paragraph;
+                position.offset = 0;
             }
         } else {
             position.offset = next_offset;
@@ -178,7 +180,9 @@ impl RichText {
     pub fn position_before(&self, mut position: RichTextPosition) -> RichTextPosition {
         if position.offset == 0 {
             if position.paragraph > 0 {
-                todo!("Need to support multiple paragraphs")
+                let data = self.data.lock();
+                position.paragraph -= 1;
+                position.offset = data.paragraphs[position.paragraph].len();
             }
         } else {
             position.offset -= 1;

--- a/text/src/wrap.rs
+++ b/text/src/wrap.rs
@@ -2,7 +2,7 @@ use approx::abs_diff_eq;
 use gooey_core::{
     figures::{Figure, Size},
     styles::Style,
-    Points,
+    Scaled,
 };
 use gooey_renderer::{Renderer, TextMetrics};
 
@@ -29,9 +29,9 @@ pub(crate) enum ParserStatus {
 }
 
 struct TextWrapState {
-    width: Option<Figure<f32, Points>>,
-    current_vmetrics: Option<TextMetrics<Points>>,
-    current_span_offset: Figure<f32, Points>,
+    width: Option<Figure<f32, Scaled>>,
+    current_vmetrics: Option<TextMetrics<Scaled>>,
+    current_span_offset: Figure<f32, Scaled>,
     current_groups: Vec<SpanGroup>,
     lines: Vec<PreparedLine>,
 }
@@ -53,7 +53,7 @@ impl TextWrapState {
 
             if let Some(width) = self.width {
                 let new_width = total_width + self.current_span_offset;
-                let remaining_width: Figure<f32, Points> = width - new_width;
+                let remaining_width: Figure<f32, Scaled> = width - new_width;
 
                 // If the value is negative and isn't zero (-0. is a valid float)
                 if !abs_diff_eq!(remaining_width.get(), 0., epsilon = 0.1)
@@ -77,7 +77,7 @@ impl TextWrapState {
         }
     }
 
-    fn update_vmetrics(&mut self, new_metrics: TextMetrics<Points>) {
+    fn update_vmetrics(&mut self, new_metrics: TextMetrics<Scaled>) {
         self.current_vmetrics = match self.current_vmetrics {
             Some(metrics) => Some(TextMetrics {
                 ascent: metrics.ascent.max(new_metrics.ascent),
@@ -198,12 +198,12 @@ pub enum TextWrap {
     /// Render the text in a single line. Do not render past `max_width`.
     SingleLine {
         /// The width of the line to render within.
-        width: Figure<f32, Points>,
+        width: Figure<f32, Scaled>,
     },
     /// Render a multi-line text block.
     MultiLine {
         /// The size of the text area.
-        size: Size<f32, Points>,
+        size: Size<f32, Scaled>,
     },
 }
 
@@ -222,7 +222,7 @@ impl TextWrap {
 
     /// Returns the width of the rendered area, if one was provided.
     #[must_use]
-    pub fn width(&self) -> Option<Figure<f32, Points>> {
+    pub fn width(&self) -> Option<Figure<f32, Scaled>> {
         match self {
             Self::MultiLine { size, .. } => Some(Figure::new(size.width)),
             Self::SingleLine { width, .. } => Some(*width),
@@ -232,7 +232,7 @@ impl TextWrap {
 
     /// Returns the height of the rendendered area, if one was provided.
     #[must_use]
-    pub fn height(&self) -> Option<Figure<f32, Points>> {
+    pub fn height(&self) -> Option<Figure<f32, Scaled>> {
         match self {
             Self::MultiLine { size, .. } => Some(Figure::new(size.height)),
             _ => None,
@@ -243,8 +243,8 @@ impl TextWrap {
 #[cfg(test)]
 mod tests {
     use gooey_core::{
+        figures::DisplayScale,
         styles::{FontSize, Style, SystemTheme},
-        Pixels,
     };
     use gooey_renderer::StrokeOptions;
 
@@ -259,25 +259,25 @@ mod tests {
             SystemTheme::default()
         }
 
-        fn size(&self) -> gooey_core::figures::Size<f32, Points> {
+        fn size(&self) -> gooey_core::figures::Size<f32, Scaled> {
             unimplemented!()
         }
 
-        fn clip_to(&self, _bounds: gooey_core::figures::Rect<f32, Points>) -> Self {
+        fn clip_to(&self, _bounds: gooey_core::figures::Rect<f32, Scaled>) -> Self {
             unimplemented!()
         }
 
-        fn clip_bounds(&self) -> gooey_core::figures::Rect<f32, Points> {
+        fn clip_bounds(&self) -> gooey_core::figures::Rect<f32, Scaled> {
             unimplemented!()
         }
 
-        fn scale(&self) -> gooey_core::figures::Scale<f32, Points, Pixels> {
+        fn scale(&self) -> DisplayScale<f32> {
             unimplemented!()
         }
 
         fn stroke_rect(
             &self,
-            _rect: &gooey_core::figures::Rect<f32, Points>,
+            _rect: &gooey_core::figures::Rect<f32, Scaled>,
             _style: &StrokeOptions,
         ) {
             unimplemented!()
@@ -285,7 +285,7 @@ mod tests {
 
         fn fill_rect(
             &self,
-            _rect: &gooey_core::figures::Rect<f32, Points>,
+            _rect: &gooey_core::figures::Rect<f32, Scaled>,
             _color: gooey_core::styles::Color,
         ) {
             unimplemented!()
@@ -293,8 +293,8 @@ mod tests {
 
         fn stroke_line(
             &self,
-            _point_a: gooey_core::figures::Point<f32, Points>,
-            _point_b: gooey_core::figures::Point<f32, Points>,
+            _point_a: gooey_core::figures::Point<f32, Scaled>,
+            _point_b: gooey_core::figures::Point<f32, Scaled>,
             _style: &StrokeOptions,
         ) {
             unimplemented!()
@@ -303,7 +303,7 @@ mod tests {
         fn render_text(
             &self,
             _text: &str,
-            _baseline_origin: gooey_core::figures::Point<f32, Points>,
+            _baseline_origin: gooey_core::figures::Point<f32, Scaled>,
             _options: &gooey_renderer::TextOptions,
         ) {
             unimplemented!()
@@ -314,7 +314,7 @@ mod tests {
             &self,
             text: &str,
             options: &gooey_renderer::TextOptions,
-        ) -> TextMetrics<Points> {
+        ) -> TextMetrics<Scaled> {
             // Return a fixed width per character, based on the font size.;
             TextMetrics {
                 width: options.text_size * text.len() as f32 * 0.6,
@@ -327,7 +327,7 @@ mod tests {
         fn draw_image(
             &self,
             _image: &gooey_core::assets::Image,
-            _location: gooey_core::figures::Point<f32, Points>,
+            _location: gooey_core::figures::Point<f32, Scaled>,
         ) {
             unimplemented!()
         }

--- a/text/src/wrap.rs
+++ b/text/src/wrap.rs
@@ -263,11 +263,11 @@ mod tests {
             unimplemented!()
         }
 
-        fn clip_to(&self, _bounds: gooey_core::figures::SizedRect<f32, Points>) -> Self {
+        fn clip_to(&self, _bounds: gooey_core::figures::Rect<f32, Points>) -> Self {
             unimplemented!()
         }
 
-        fn clip_bounds(&self) -> gooey_core::figures::SizedRect<f32, Points> {
+        fn clip_bounds(&self) -> gooey_core::figures::Rect<f32, Points> {
             unimplemented!()
         }
 
@@ -277,7 +277,7 @@ mod tests {
 
         fn stroke_rect(
             &self,
-            _rect: &gooey_core::figures::SizedRect<f32, Points>,
+            _rect: &gooey_core::figures::Rect<f32, Points>,
             _style: &StrokeOptions,
         ) {
             unimplemented!()
@@ -285,7 +285,7 @@ mod tests {
 
         fn fill_rect(
             &self,
-            _rect: &gooey_core::figures::SizedRect<f32, Points>,
+            _rect: &gooey_core::figures::Rect<f32, Points>,
             _color: gooey_core::styles::Color,
         ) {
             unimplemented!()

--- a/text/src/wrap.rs
+++ b/text/src/wrap.rs
@@ -191,7 +191,7 @@ impl<'a, R: Renderer> TextWrapper<'a, R> {
 }
 
 /// Text wrapping options.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum TextWrap {
     /// Do not wrap the text.
     NoWrap,

--- a/text/src/wrap/measured.rs
+++ b/text/src/wrap/measured.rs
@@ -1,4 +1,4 @@
-use gooey_core::{styles::Style, Points};
+use gooey_core::{styles::Style, Scaled};
 use gooey_renderer::{Renderer, TextMetrics};
 
 use super::{ParserStatus, SpanGroup, Token, Tokenizer};
@@ -12,14 +12,14 @@ pub struct MeasuredText {
 #[derive(Debug)]
 pub(crate) enum MeasuredTextInfo {
     Groups(Vec<SpanGroup>),
-    NoText(TextMetrics<Points>),
+    NoText(TextMetrics<Scaled>),
 }
 
 struct TextMeasureState {
     current_group: Option<SpanGroup>,
     status: ParserStatus,
     groups: Vec<SpanGroup>,
-    no_text_metrics: Option<TextMetrics<Points>>,
+    no_text_metrics: Option<TextMetrics<Scaled>>,
 }
 
 impl TextMeasureState {

--- a/text/src/wrap/tokenizer.rs
+++ b/text/src/wrap/tokenizer.rs
@@ -49,6 +49,7 @@ pub(crate) struct Tokenizer {
 
 struct TokenizerState {
     style: Arc<Style>,
+    character_position: usize,
     text: String,
     lexer_state: TokenizerStatus,
 }
@@ -57,6 +58,7 @@ impl TokenizerState {
     pub(crate) fn new(style: Style) -> Self {
         Self {
             style: Arc::new(style),
+            character_position: 0,
             lexer_state: TokenizerStatus::AtSpanStart,
             text: String::default(),
         }
@@ -69,7 +71,8 @@ impl TokenizerState {
             let text = self.text.clone();
             self.text.clear();
             let metrics = renderer.measure_text_with_style(&text, &self.style);
-            let span = PreparedSpan::new(self.style.clone(), text, metrics);
+            let span =
+                PreparedSpan::new(self.style.clone(), text, self.character_position, metrics);
 
             let token = match self.lexer_state {
                 TokenizerStatus::AtSpanStart => unreachable!(),
@@ -130,6 +133,8 @@ impl Tokenizer {
 
                     state.text.push(c);
                 }
+
+                state.character_position += 1;
             }
 
             if let Some(token) = state.emit_token_if_needed(renderer) {

--- a/text/src/wrap/tokenizer.rs
+++ b/text/src/wrap/tokenizer.rs
@@ -1,24 +1,24 @@
 use std::sync::Arc;
 
-use gooey_core::{styles::Style, Points};
+use gooey_core::{styles::Style, Scaled};
 use gooey_renderer::{Renderer, TextMetrics};
 
 use crate::{prepared::PreparedSpan, Text};
 
 #[derive(Debug)]
 pub(crate) enum Token {
-    EndOfLine(TextMetrics<Points>),
+    EndOfLine(TextMetrics<Scaled>),
     Characters(PreparedSpan),
     Punctuation(PreparedSpan),
     Whitespace(PreparedSpan),
-    NoText(Option<TextMetrics<Points>>),
+    NoText(Option<TextMetrics<Scaled>>),
 }
 
 #[derive(Debug)]
 pub(crate) enum SpanGroup {
     Spans(Vec<PreparedSpan>),
     Whitespace(Vec<PreparedSpan>),
-    EndOfLine(TextMetrics<Points>),
+    EndOfLine(TextMetrics<Scaled>),
 }
 
 impl SpanGroup {

--- a/widgets/Cargo.toml
+++ b/widgets/Cargo.toml
@@ -16,14 +16,14 @@ frontend-rasterizer = ["gooey-rasterizer"]
 frontend-browser = ["gooey-browser", "wasm-bindgen", "web-sys"]
 
 [dependencies]
-gooey-core = { path="../core", version="0.1.0-dev.0" }
-gooey-text = { path="../text", version="0.1.0-dev.0" }
-gooey-renderer = { path="../renderer", version="0.1.0-dev.0" }
-gooey-rasterizer = { path="../frontends/rasterizer", version="0.1.0-dev.0", optional=true }
-gooey-browser = { path="../frontends/browser", version="0.1.0-dev.0", optional=true }
+gooey-core = { path = "../core", version = "0.1.0-dev.0" }
+gooey-text = { path = "../text", version = "0.1.0-dev.0" }
+gooey-renderer = { path = "../renderer", version = "0.1.0-dev.0" }
+gooey-rasterizer = { path = "../frontends/rasterizer", version = "0.1.0-dev.0", optional = true }
+gooey-browser = { path = "../frontends/browser", version = "0.1.0-dev.0", optional = true }
 
-wasm-bindgen = { version="0.2", optional=true }
-web-sys = { version="0.3", features=[
+wasm-bindgen = { version = "0.2", optional = true }
+web-sys = { version = "0.3", features = [
     "Document",
     "CssStyleSheet",
     "CssRule",
@@ -39,6 +39,7 @@ web-sys = { version="0.3", features=[
     "HtmlLabelElement",
     "HtmlSpanElement",
     "CssStyleDeclaration",
-], optional=true }
+], optional = true }
 flume = "0.10"
 log = "0.4"
+parking_lot = "0.11"

--- a/widgets/Cargo.toml
+++ b/widgets/Cargo.toml
@@ -13,7 +13,7 @@ readme = "../README.md"
 [features]
 default = []
 frontend-rasterizer = ["gooey-rasterizer"]
-frontend-browser = ["gooey-browser", "wasm-bindgen", "web-sys"]
+frontend-browser = ["gooey-browser", "wasm-bindgen", "web-sys", "arboard"]
 
 [dependencies]
 gooey-core = { path = "../core", version = "0.1.0-dev.0" }
@@ -21,6 +21,8 @@ gooey-text = { path = "../text", version = "0.1.0-dev.0" }
 gooey-renderer = { path = "../renderer", version = "0.1.0-dev.0" }
 gooey-rasterizer = { path = "../frontends/rasterizer", version = "0.1.0-dev.0", optional = true }
 gooey-browser = { path = "../frontends/browser", version = "0.1.0-dev.0", optional = true }
+
+arboard = { version = "2", optional = true }
 
 wasm-bindgen = { version = "0.2", optional = true }
 web-sys = { version = "0.3", features = [
@@ -43,3 +45,6 @@ web-sys = { version = "0.3", features = [
 flume = "0.10"
 log = "0.4"
 parking_lot = "0.11"
+
+[target.'cfg(target_arch="wasm32")'.dependencies]
+parking_lot = { version = "0.11", features = ["wasm-bindgen"] }

--- a/widgets/Cargo.toml
+++ b/widgets/Cargo.toml
@@ -12,8 +12,8 @@ readme = "../README.md"
 
 [features]
 default = []
-frontend-rasterizer = ["gooey-rasterizer"]
-frontend-browser = ["gooey-browser", "wasm-bindgen", "web-sys", "arboard"]
+frontend-rasterizer = ["gooey-rasterizer", "arboard"]
+frontend-browser = ["gooey-browser", "wasm-bindgen", "web-sys"]
 
 [dependencies]
 gooey-core = { path = "../core", version = "0.1.0-dev.0" }

--- a/widgets/src/button/rasterizer.rs
+++ b/widgets/src/button/rasterizer.rs
@@ -1,7 +1,7 @@
 use gooey_core::{
     figures::{Figure, Point, Rectlike, Size},
     styles::{Style, TextColor},
-    Points, Transmogrifier, TransmogrifierContext,
+    Scaled, Transmogrifier, TransmogrifierContext,
 };
 use gooey_rasterizer::{
     winit::event::MouseButton, ContentArea, EventStatus, Rasterizer, Renderer,
@@ -49,8 +49,8 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
     fn measure_content(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
-    ) -> Size<f32, Points> {
+        constraints: Size<Option<f32>, Scaled>,
+    ) -> Size<f32, Scaled> {
         context
             .frontend
             .renderer()
@@ -69,7 +69,7 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         button: MouseButton,
-        _location: Point<f32, Points>,
+        _location: Point<f32, Scaled>,
         _area: &ContentArea,
     ) -> EventStatus {
         if button == MouseButton::Left {
@@ -84,7 +84,7 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         _button: MouseButton,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) {
         if area.bounds().contains(location) {
@@ -98,7 +98,7 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         _button: MouseButton,
-        location: Option<Point<f32, Points>>,
+        location: Option<Point<f32, Scaled>>,
         area: &ContentArea,
     ) {
         if location
@@ -124,7 +124,7 @@ fn wrap_text<R: Renderer>(
     label: &str,
     style: &Style,
     renderer: &R,
-    width: Figure<f32, Points>,
+    width: Figure<f32, Scaled>,
 ) -> PreparedText {
     let text = Text::span(label, style.clone());
     text.wrap(renderer, TextWrap::SingleLine { width }, Some(style))

--- a/widgets/src/button/rasterizer.rs
+++ b/widgets/src/button/rasterizer.rs
@@ -1,5 +1,5 @@
 use gooey_core::{
-    euclid::{Length, Point2D, Size2D},
+    figures::{Figure, Point, Rectlike, Size},
     styles::{Style, TextColor},
     Points, Transmogrifier, TransmogrifierContext,
 };
@@ -35,7 +35,7 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
                 &context.widget.label,
                 context.style,
                 renderer,
-                Length::new(content_area.size.content.width),
+                Figure::new(content_area.size.content.width),
             );
 
             wrapped.render_within::<TextColor, _>(
@@ -49,17 +49,17 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
     fn measure_content(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size2D<Option<f32>, Points>,
-    ) -> Size2D<f32, Points> {
+        constraints: Size<Option<f32>, Points>,
+    ) -> Size<f32, Points> {
         context
             .frontend
             .renderer()
-            .map_or_else(Size2D::default, |renderer| {
+            .map_or_else(Size::default, |renderer| {
                 wrap_text(
                     &context.widget.label,
                     context.style,
                     renderer,
-                    Length::new(constraints.width.unwrap_or_else(|| renderer.size().width)),
+                    Figure::new(constraints.width.unwrap_or_else(|| renderer.size().width)),
                 )
                 .size()
             })
@@ -69,7 +69,7 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         button: MouseButton,
-        _location: Point2D<f32, Points>,
+        _location: Point<f32, Points>,
         _area: &ContentArea,
     ) -> EventStatus {
         if button == MouseButton::Left {
@@ -84,7 +84,7 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         _button: MouseButton,
-        location: Point2D<f32, Points>,
+        location: Point<f32, Points>,
         area: &ContentArea,
     ) {
         if area.bounds().contains(location) {
@@ -98,7 +98,7 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         _button: MouseButton,
-        location: Option<Point2D<f32, Points>>,
+        location: Option<Point<f32, Points>>,
         area: &ContentArea,
     ) {
         if location
@@ -124,7 +124,7 @@ fn wrap_text<R: Renderer>(
     label: &str,
     style: &Style,
     renderer: &R,
-    width: Length<f32, Points>,
+    width: Figure<f32, Points>,
 ) -> PreparedText {
     let text = Text::span(label, style.clone());
     text.wrap(renderer, TextWrap::SingleLine { width }, Some(style))

--- a/widgets/src/button/rasterizer.rs
+++ b/widgets/src/button/rasterizer.rs
@@ -1,5 +1,5 @@
 use gooey_core::{
-    euclid::{Length, Point2D, Rect, Size2D},
+    euclid::{Length, Point2D, Size2D},
     styles::{Style, TextColor},
     Points, Transmogrifier, TransmogrifierContext,
 };

--- a/widgets/src/button/rasterizer.rs
+++ b/widgets/src/button/rasterizer.rs
@@ -4,7 +4,8 @@ use gooey_core::{
     Points, Transmogrifier, TransmogrifierContext,
 };
 use gooey_rasterizer::{
-    winit::event::MouseButton, ContentArea, EventStatus, Rasterizer, Renderer, WidgetRasterizer,
+    winit::event::MouseButton, ContentArea, EventStatus, Rasterizer, Renderer,
+    TransmogrifierContextExt, WidgetRasterizer,
 };
 use gooey_text::{prepared::PreparedText, wrap::TextWrap, Text};
 
@@ -37,7 +38,11 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
                 Length::new(content_area.size.content.width),
             );
 
-            wrapped.render_within::<TextColor, _>(renderer, content_area.bounds(), context.style);
+            wrapped.render_within::<TextColor, _>(
+                renderer,
+                content_area.content_bounds(),
+                context.style,
+            );
         }
     }
 
@@ -65,10 +70,10 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         button: MouseButton,
         _location: Point2D<f32, Points>,
-        _rastered_size: Size2D<f32, Points>,
+        _area: &ContentArea,
     ) -> EventStatus {
         if button == MouseButton::Left {
-            context.frontend.activate(context.registration.id());
+            context.activate();
             EventStatus::Processed
         } else {
             EventStatus::Ignored
@@ -80,10 +85,10 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         _button: MouseButton,
         location: Point2D<f32, Points>,
-        rastered_size: Size2D<f32, Points>,
+        area: &ContentArea,
     ) {
-        if Rect::from_size(rastered_size).contains(location) {
-            context.frontend.activate(context.registration.id());
+        if area.bounds().contains(location) {
+            context.activate();
         } else {
             context.frontend.blur();
         }
@@ -94,10 +99,10 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         _button: MouseButton,
         location: Option<Point2D<f32, Points>>,
-        rastered_size: Size2D<f32, Points>,
+        area: &ContentArea,
     ) {
         if location
-            .map(|location| Rect::new(Point2D::default(), rastered_size).contains(location))
+            .map(|location| area.bounds().contains(location))
             .unwrap_or_default()
         {
             if let Some(widget) = context
@@ -111,7 +116,7 @@ impl<R: Renderer> WidgetRasterizer<R> for ButtonTransmogrifier {
                     .post_event(InternalButtonEvent::Clicked);
             }
         }
-        context.frontend.deactivate();
+        context.deactivate();
     }
 }
 

--- a/widgets/src/checkbox.rs
+++ b/widgets/src/checkbox.rs
@@ -1,4 +1,4 @@
-use gooey_core::{figures::Figure, Callback, Context, Points, StyledWidget, Widget};
+use gooey_core::{figures::Figure, Callback, Context, Scaled, StyledWidget, Widget};
 
 #[cfg(feature = "gooey-rasterizer")]
 mod rasterizer;
@@ -6,7 +6,7 @@ mod rasterizer;
 #[cfg(feature = "frontend-browser")]
 mod browser;
 
-pub const LABEL_PADDING: Figure<f32, Points> = Figure::new(5.);
+pub const LABEL_PADDING: Figure<f32, Scaled> = Figure::new(5.);
 
 #[derive(Default, Debug)]
 pub struct Checkbox {

--- a/widgets/src/checkbox.rs
+++ b/widgets/src/checkbox.rs
@@ -1,4 +1,4 @@
-use gooey_core::{euclid::Length, Callback, Context, Points, StyledWidget, Widget};
+use gooey_core::{figures::Figure, Callback, Context, Points, StyledWidget, Widget};
 
 #[cfg(feature = "gooey-rasterizer")]
 mod rasterizer;
@@ -6,7 +6,7 @@ mod rasterizer;
 #[cfg(feature = "frontend-browser")]
 mod browser;
 
-pub const LABEL_PADDING: Length<f32, Points> = Length::new(5.);
+pub const LABEL_PADDING: Figure<f32, Points> = Figure::new(5.);
 
 #[derive(Default, Debug)]
 pub struct Checkbox {

--- a/widgets/src/checkbox/rasterizer.rs
+++ b/widgets/src/checkbox/rasterizer.rs
@@ -4,7 +4,8 @@ use gooey_core::{
     Points, Transmogrifier, TransmogrifierContext,
 };
 use gooey_rasterizer::{
-    winit::event::MouseButton, ContentArea, EventStatus, Rasterizer, Renderer, WidgetRasterizer,
+    winit::event::MouseButton, ContentArea, EventStatus, Rasterizer, Renderer,
+    TransmogrifierContextExt, WidgetRasterizer,
 };
 use gooey_text::{prepared::PreparedText, wrap::TextWrap, Text};
 
@@ -132,10 +133,10 @@ impl<R: Renderer> WidgetRasterizer<R> for CheckboxTransmogrifier {
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         button: MouseButton,
         _location: Point2D<f32, Points>,
-        _rastered_size: Size2D<f32, Points>,
+        _area: &ContentArea,
     ) -> EventStatus {
         if button == MouseButton::Left {
-            context.frontend.activate(context.registration.id());
+            context.activate();
             EventStatus::Processed
         } else {
             EventStatus::Ignored
@@ -147,10 +148,10 @@ impl<R: Renderer> WidgetRasterizer<R> for CheckboxTransmogrifier {
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         _button: MouseButton,
         location: Point2D<f32, Points>,
-        rastered_size: Size2D<f32, Points>,
+        area: &ContentArea,
     ) {
-        if Rect::from_size(rastered_size).contains(location) {
-            context.frontend.activate(context.registration.id());
+        if area.bounds().contains(location) {
+            context.activate();
         } else {
             context.frontend.blur();
         }
@@ -161,10 +162,10 @@ impl<R: Renderer> WidgetRasterizer<R> for CheckboxTransmogrifier {
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         _button: MouseButton,
         location: Option<Point2D<f32, Points>>,
-        rastered_size: Size2D<f32, Points>,
+        area: &ContentArea,
     ) {
         if location
-            .map(|location| Rect::new(Point2D::default(), rastered_size).contains(location))
+            .map(|location| area.bounds().contains(location))
             .unwrap_or_default()
         {
             if let Some(widget) = context
@@ -178,6 +179,6 @@ impl<R: Renderer> WidgetRasterizer<R> for CheckboxTransmogrifier {
                     .post_event(InternalCheckboxEvent::Clicked);
             }
         }
-        context.frontend.deactivate();
+        context.deactivate();
     }
 }

--- a/widgets/src/checkbox/rasterizer.rs
+++ b/widgets/src/checkbox/rasterizer.rs
@@ -1,7 +1,7 @@
 use gooey_core::{
     figures::{Point, Rect, Rectlike, Size, SizedRect, Vector},
     styles::ForegroundColor,
-    Points, Transmogrifier, TransmogrifierContext,
+    Scaled, Transmogrifier, TransmogrifierContext,
 };
 use gooey_rasterizer::{
     winit::event::MouseButton, ContentArea, EventStatus, Rasterizer, Renderer,
@@ -31,16 +31,16 @@ impl<R: Renderer> Transmogrifier<Rasterizer<R>> for CheckboxTransmogrifier {
 
 #[derive(Clone, Default, Debug)]
 pub struct LayoutState {
-    content_size: Size<f32, Points>,
-    checkbox_size: Size<f32, Points>,
-    label_size: Size<f32, Points>,
+    content_size: Size<f32, Scaled>,
+    checkbox_size: Size<f32, Scaled>,
+    label_size: Size<f32, Scaled>,
     label: PreparedText,
 }
 
 fn calculate_layout<R: Renderer>(
     context: &TransmogrifierContext<'_, CheckboxTransmogrifier, Rasterizer<R>>,
     renderer: &R,
-    size: Size<f32, Points>,
+    size: Size<f32, Scaled>,
 ) -> LayoutState {
     // Determine the checkbox size by figuring out the line height
     let line_height = renderer
@@ -106,8 +106,8 @@ impl<R: Renderer> WidgetRasterizer<R> for CheckboxTransmogrifier {
     fn measure_content(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
-    ) -> Size<f32, Points> {
+        constraints: Size<Option<f32>, Scaled>,
+    ) -> Size<f32, Scaled> {
         // Always render a rect
         context
             .frontend
@@ -131,7 +131,7 @@ impl<R: Renderer> WidgetRasterizer<R> for CheckboxTransmogrifier {
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         button: MouseButton,
-        _location: Point<f32, Points>,
+        _location: Point<f32, Scaled>,
         _area: &ContentArea,
     ) -> EventStatus {
         if button == MouseButton::Left {
@@ -146,7 +146,7 @@ impl<R: Renderer> WidgetRasterizer<R> for CheckboxTransmogrifier {
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         _button: MouseButton,
-        location: Point<f32, Points>,
+        location: Point<f32, Scaled>,
         area: &ContentArea,
     ) {
         if area.bounds().contains(location) {
@@ -160,7 +160,7 @@ impl<R: Renderer> WidgetRasterizer<R> for CheckboxTransmogrifier {
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         _button: MouseButton,
-        location: Option<Point<f32, Points>>,
+        location: Option<Point<f32, Scaled>>,
         area: &ContentArea,
     ) {
         if location

--- a/widgets/src/checkbox/rasterizer.rs
+++ b/widgets/src/checkbox/rasterizer.rs
@@ -1,5 +1,5 @@
 use gooey_core::{
-    figures::{Point, Rect, Rectlike, Size, SizedRect, Vector, Vectorlike},
+    figures::{Point, Rect, Rectlike, Size, SizedRect, Vector},
     styles::ForegroundColor,
     Points, Transmogrifier, TransmogrifierContext,
 };
@@ -62,9 +62,7 @@ fn calculate_layout<R: Renderer>(
     let label_size = label.size();
 
     LayoutState {
-        content_size: (label_size.to_vector()
-            + Vector::new(checkbox_size.width + LABEL_PADDING.get(), 0.))
-        .to_size(),
+        content_size: label_size + Vector::new(checkbox_size.width + LABEL_PADDING.get(), 0.),
         checkbox_size,
         label_size,
         label,
@@ -96,7 +94,7 @@ impl<R: Renderer> WidgetRasterizer<R> for CheckboxTransmogrifier {
             // Render the label
             let label_rect = Rect::sized(
                 Point::new(layout.checkbox_size.width + LABEL_PADDING.get(), 0.)
-                    + content_area.location.to_vector(),
+                    + content_area.location,
                 layout.label_size,
             );
             layout

--- a/widgets/src/checkbox/rasterizer.rs
+++ b/widgets/src/checkbox/rasterizer.rs
@@ -1,5 +1,5 @@
 use gooey_core::{
-    figures::{Point, Rectlike, Size, SizedRect, Vector, Vectorlike},
+    figures::{Point, Rect, Rectlike, Size, SizedRect, Vector, Vectorlike},
     styles::ForegroundColor,
     Points, Transmogrifier, TransmogrifierContext,
 };
@@ -82,18 +82,19 @@ impl<R: Renderer> WidgetRasterizer<R> for CheckboxTransmogrifier {
 
             // Render the checkbox
             let checkbox_rect = SizedRect::new(content_area.location, layout.checkbox_size);
-            renderer.fill_rect_with_style::<ButtonColor>(&checkbox_rect, context.style);
+            renderer.fill_rect_with_style::<ButtonColor>(&checkbox_rect.as_rect(), context.style);
             if context.widget.checked {
                 // Fill a square in the middle with the mark.
                 let check_box = checkbox_rect.inflate(Vector::new(
                     -checkbox_rect.size.width / 3.,
                     -checkbox_rect.size.width / 3.,
                 ));
-                renderer.fill_rect_with_style::<ForegroundColor>(&check_box, context.style);
+                renderer
+                    .fill_rect_with_style::<ForegroundColor>(&check_box.as_rect(), context.style);
             }
 
             // Render the label
-            let label_rect = SizedRect::new(
+            let label_rect = Rect::sized(
                 Point::new(layout.checkbox_size.width + LABEL_PADDING.get(), 0.)
                     + content_area.location.to_vector(),
                 layout.label_size,

--- a/widgets/src/component/rasterizer.rs
+++ b/widgets/src/component/rasterizer.rs
@@ -1,6 +1,4 @@
-use gooey_core::{
-    euclid::Size2D, Points, Transmogrifier, TransmogrifierContext, Widget, WidgetRef,
-};
+use gooey_core::{figures::Size, Points, Transmogrifier, TransmogrifierContext, Widget, WidgetRef};
 use gooey_rasterizer::{ContentArea, Rasterizer, Renderer, WidgetRasterizer};
 
 use super::Component;
@@ -27,8 +25,8 @@ impl<R: Renderer, B: Behavior> WidgetRasterizer<R> for ComponentTransmogrifier<B
     fn measure_content(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size2D<Option<f32>, Points>,
-    ) -> Size2D<f32, Points> {
+        constraints: Size<Option<f32>, Points>,
+    ) -> Size<f32, Points> {
         context
             .frontend
             .with_transmogrifier(

--- a/widgets/src/component/rasterizer.rs
+++ b/widgets/src/component/rasterizer.rs
@@ -17,7 +17,7 @@ impl<R: Renderer, B: Behavior> WidgetRasterizer<R> for ComponentTransmogrifier<B
             |child_transmogrifier, mut child_context| {
                 child_transmogrifier.render_within(
                     &mut child_context,
-                    content_area.bounds(),
+                    content_area.content_bounds(),
                     context.style,
                 );
             },

--- a/widgets/src/component/rasterizer.rs
+++ b/widgets/src/component/rasterizer.rs
@@ -1,4 +1,4 @@
-use gooey_core::{figures::Size, Points, Transmogrifier, TransmogrifierContext, Widget, WidgetRef};
+use gooey_core::{figures::Size, Scaled, Transmogrifier, TransmogrifierContext, Widget, WidgetRef};
 use gooey_rasterizer::{ContentArea, Rasterizer, Renderer, WidgetRasterizer};
 
 use super::Component;
@@ -25,8 +25,8 @@ impl<R: Renderer, B: Behavior> WidgetRasterizer<R> for ComponentTransmogrifier<B
     fn measure_content(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
-    ) -> Size<f32, Points> {
+        constraints: Size<Option<f32>, Scaled>,
+    ) -> Size<f32, Scaled> {
         context
             .frontend
             .with_transmogrifier(

--- a/widgets/src/container.rs
+++ b/widgets/src/container.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, marker::PhantomData};
 
 use gooey_core::{
-    styles::Surround, Frontend, Key, KeyedStorage, Points, RelatedStorage, StyledWidget, Widget,
+    styles::Surround, Frontend, Key, KeyedStorage, RelatedStorage, Scaled, StyledWidget, Widget,
     WidgetRef, WidgetRegistration, WidgetStorage,
 };
 
@@ -49,7 +49,7 @@ impl<B: Behavior> Content<B> for Container {
 pub struct Builder<K: Key, S: KeyedStorage<K>> {
     storage: S,
     child: Option<WidgetRegistration>,
-    padding: Surround<Points>,
+    padding: Surround<Scaled>,
     _phantom: PhantomData<K>,
 }
 

--- a/widgets/src/container/rasterizer.rs
+++ b/widgets/src/container/rasterizer.rs
@@ -1,5 +1,5 @@
 use gooey_core::{
-    euclid::{Point2D, Rect, Size2D},
+    figures::{Point, Size, SizedRect},
     Points, Transmogrifier, TransmogrifierContext,
 };
 use gooey_rasterizer::{ContentArea, Rasterizer, Renderer, WidgetRasterizer};
@@ -23,7 +23,7 @@ impl<R: Renderer> WidgetRasterizer<R> for ContainerTransmogrifier {
                 let child_content_area = child_transmogrifier
                     .content_size(
                         &mut child_context,
-                        Size2D::new(
+                        Size::new(
                             Some(content_area.size.content.width),
                             Some(content_area.size.content.height),
                         ),
@@ -32,8 +32,8 @@ impl<R: Renderer> WidgetRasterizer<R> for ContainerTransmogrifier {
                 let remaining_size = content_area.size.content - child_content_area;
 
                 // TODO respect Alignment + Vertical alignment
-                let child_rect = Rect::new(
-                    Point2D::new(remaining_size.width / 2., remaining_size.height / 2.),
+                let child_rect = SizedRect::new(
+                    Point::new(remaining_size.width / 2., remaining_size.height / 2.),
                     child_content_area,
                 );
                 child_transmogrifier.render_within(&mut child_context, child_rect, context.style);
@@ -44,8 +44,8 @@ impl<R: Renderer> WidgetRasterizer<R> for ContainerTransmogrifier {
     fn measure_content(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size2D<Option<f32>, Points>,
-    ) -> Size2D<f32, Points> {
+        constraints: Size<Option<f32>, Points>,
+    ) -> Size<f32, Points> {
         context
             .frontend
             .with_transmogrifier(

--- a/widgets/src/container/rasterizer.rs
+++ b/widgets/src/container/rasterizer.rs
@@ -1,6 +1,6 @@
 use gooey_core::{
     figures::{Point, Rect, Size},
-    Points, Transmogrifier, TransmogrifierContext,
+    Scaled, Transmogrifier, TransmogrifierContext,
 };
 use gooey_rasterizer::{ContentArea, Rasterizer, Renderer, WidgetRasterizer};
 
@@ -44,8 +44,8 @@ impl<R: Renderer> WidgetRasterizer<R> for ContainerTransmogrifier {
     fn measure_content(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
-    ) -> Size<f32, Points> {
+        constraints: Size<Option<f32>, Scaled>,
+    ) -> Size<f32, Scaled> {
         context
             .frontend
             .with_transmogrifier(

--- a/widgets/src/container/rasterizer.rs
+++ b/widgets/src/container/rasterizer.rs
@@ -1,5 +1,5 @@
 use gooey_core::{
-    figures::{Point, Size, SizedRect},
+    figures::{Point, Rect, Size},
     Points, Transmogrifier, TransmogrifierContext,
 };
 use gooey_rasterizer::{ContentArea, Rasterizer, Renderer, WidgetRasterizer};
@@ -32,7 +32,7 @@ impl<R: Renderer> WidgetRasterizer<R> for ContainerTransmogrifier {
                 let remaining_size = content_area.size.content - child_content_area;
 
                 // TODO respect Alignment + Vertical alignment
-                let child_rect = SizedRect::new(
+                let child_rect = Rect::sized(
                     Point::new(remaining_size.width / 2., remaining_size.height / 2.),
                     child_content_area,
                 );

--- a/widgets/src/input.rs
+++ b/widgets/src/input.rs
@@ -1,0 +1,64 @@
+use gooey_core::{Callback, Context, StyledWidget, Widget};
+
+#[cfg(feature = "gooey-rasterizer")]
+mod rasterizer;
+
+#[cfg(feature = "frontend-browser")]
+mod browser;
+
+#[derive(Debug, Default)]
+pub struct Input {
+    value: String,
+    selection_start: usize,
+    selection_end: Option<usize>,
+    changed: Callback<()>,
+    selection_changed: Callback<()>,
+}
+
+impl Input {
+    pub fn new<S: Into<String>>(value: S, changed: Callback<()>) -> StyledWidget<Self> {
+        StyledWidget::from(Self {
+            value: value.into(),
+            changed,
+            ..Input::default()
+        })
+    }
+
+    pub fn set_value(&mut self, value: impl Into<String>, context: &Context<Self>) {
+        self.value = value.into();
+        context.send_command(Command::ValueSet);
+    }
+
+    pub fn set_selection(&mut self, start: usize, end: Option<usize>, context: &Context<Self>) {
+        self.selection_start = start;
+        self.selection_end = end;
+        context.send_command(Command::SelectionSet);
+    }
+
+    #[must_use]
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+#[derive(Debug)]
+pub enum Command {
+    ValueSet,
+    SelectionSet,
+}
+
+#[derive(Debug)]
+pub enum Event {
+    ValueChanged,
+    SelectionChanged,
+}
+
+impl Widget for Input {
+    type Command = Command;
+    type Event = Event;
+
+    const CLASS: &'static str = "gooey-input";
+}
+
+#[derive(Debug)]
+pub struct InputTransmogrifier;

--- a/widgets/src/input.rs
+++ b/widgets/src/input.rs
@@ -16,6 +16,10 @@ pub struct Input {
 }
 
 impl Input {
+    pub fn build() -> Builder {
+        Builder::default()
+    }
+
     pub fn new<S: Into<String>>(value: S, changed: Callback<()>) -> StyledWidget<Self> {
         StyledWidget::from(Self {
             value: value.into(),
@@ -62,3 +66,30 @@ impl Widget for Input {
 
 #[derive(Debug)]
 pub struct InputTransmogrifier;
+
+#[derive(Debug, Default)]
+#[must_use]
+pub struct Builder {
+    input: Input,
+}
+
+impl Builder {
+    pub fn value<S: Into<String>>(mut self, value: S) -> Self {
+        self.input.value = value.into();
+        self
+    }
+
+    pub fn on_changed(mut self, callback: Callback) -> Self {
+        self.input.changed = callback;
+        self
+    }
+
+    pub fn on_selection_changed(mut self, callback: Callback) -> Self {
+        self.input.selection_changed = callback;
+        self
+    }
+
+    pub fn finish(self) -> StyledWidget<Input> {
+        StyledWidget::from(self.input)
+    }
+}

--- a/widgets/src/input/browser.rs
+++ b/widgets/src/input/browser.rs
@@ -1,0 +1,110 @@
+use gooey_browser::{
+    utils::{create_element, widget_css_id, window_document, CssRules},
+    WebSys, WebSysTransmogrifier,
+};
+use gooey_core::{Context, TransmogrifierContext};
+use wasm_bindgen::{prelude::Closure, JsCast};
+use web_sys::HtmlInputElement;
+
+use crate::input::{Command, Input, InputTransmogrifier};
+
+impl gooey_core::Transmogrifier<WebSys> for InputTransmogrifier {
+    type State = Option<CssRules>;
+    type Widget = Input;
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn receive_command(
+        &self,
+        command: Command,
+        context: &mut TransmogrifierContext<'_, Self, WebSys>,
+    ) {
+        if let Some(element) = input_element(&Context::from(&*context)) {
+            match command {
+                Command::ValueSet => {
+                    element.set_value(&context.widget.value);
+                }
+                Command::SelectionSet => {
+                    let start = context.widget.selection_start;
+                    let end = context.widget.selection_end.unwrap_or(start);
+                    if end >= start {
+                        element
+                            .set_selection_range_with_direction(start as u32, end as u32, "forward")
+                            .unwrap();
+                    } else {
+                        element
+                            .set_selection_range_with_direction(
+                                end as u32,
+                                start as u32,
+                                "backward",
+                            )
+                            .unwrap();
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl WebSysTransmogrifier for InputTransmogrifier {
+    fn transmogrify(
+        &self,
+        context: TransmogrifierContext<'_, Self, WebSys>,
+    ) -> Option<web_sys::HtmlElement> {
+        let element = create_element::<HtmlInputElement>("input");
+        *context.state = self.initialize_widget_element(&element, &context);
+        element.set_value(&context.widget.value);
+
+        let callback_context = Context::from(&context);
+        element.set_onchange(
+            Closure::wrap(Box::new(move || {
+                callback_context.map_mut(|input, context| {
+                    if let Some(element) = input_element(context) {
+                        input.value = element.value();
+                        input.changed.invoke(());
+                    }
+                });
+            }) as Box<dyn FnMut()>)
+            .as_ref()
+            .dyn_ref(),
+        );
+
+        let callback_context = Context::from(&context);
+        element.set_onselect(
+            Closure::wrap(Box::new(move || {
+                callback_context.map_mut(|input, context| {
+                    if let Some(element) = input_element(context) {
+                        let start = element
+                            .selection_start()
+                            .unwrap_or_default()
+                            .unwrap_or_default() as usize;
+                        let end = element
+                            .selection_end()
+                            .unwrap_or_default()
+                            .unwrap_or_default() as usize;
+                        let direction = element.selection_direction().unwrap_or_default();
+                        let (start, end) = match direction.as_deref() {
+                            Some("backward") => (end, start),
+                            _ => (start, end),
+                        };
+                        let end = if start == end { None } else { Some(end) };
+                        input.selection_start = start;
+                        input.selection_end = end;
+                        input.selection_changed.invoke(());
+                    }
+                });
+            }) as Box<dyn FnMut()>)
+            .as_ref()
+            .dyn_ref(),
+        );
+
+        Some(element.unchecked_into())
+    }
+}
+
+fn input_element(context: &Context<Input>) -> Option<HtmlInputElement> {
+    window_document()
+        .get_element_by_id(&widget_css_id(
+            context.registration().upgrade().unwrap().id().id,
+        ))
+        .map(JsCast::unchecked_into::<HtmlInputElement>)
+}

--- a/widgets/src/input/rasterizer.rs
+++ b/widgets/src/input/rasterizer.rs
@@ -1,0 +1,539 @@
+use std::{
+    marker::PhantomData,
+    time::{Duration, Instant},
+};
+
+use gooey_core::{
+    euclid::{Length, Point2D, Rect, Size2D},
+    styles::{Color, Style, TextColor},
+    Context, Points, Transmogrifier, TransmogrifierContext,
+};
+use gooey_rasterizer::{
+    winit::event::MouseButton, ContentArea, EventStatus, Rasterizer, Renderer,
+    TransmogrifierContextExt, WidgetRasterizer,
+};
+use gooey_text::{
+    prepared::PreparedText,
+    rich::{RichText, RichTextPosition},
+    wrap::TextWrap,
+    Text,
+};
+
+use crate::input::{Command, Input, InputTransmogrifier};
+
+// TODO implement this as an actual lookup on platforms that support it.
+const CURSOR_BLINK_MS: u64 = 500;
+
+impl<R: Renderer> Transmogrifier<Rasterizer<R>> for InputTransmogrifier {
+    type State = InputState<R>;
+    type Widget = Input;
+
+    fn receive_command(
+        &self,
+        command: Command,
+        context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
+    ) {
+        match command {
+            Command::ValueSet => {
+                context.state.text = RichText::from(context.widget.value.as_str());
+                context.state.prepared = None;
+            }
+            Command::SelectionSet => {
+                context.state.cursor.start = context
+                    .state
+                    .text
+                    .position_of_character(context.widget.selection_start);
+                context.state.cursor.end = context
+                    .widget
+                    .selection_end
+                    .map(|offset| context.state.text.position_of_character(offset));
+            }
+        }
+        context.frontend.set_needs_redraw();
+    }
+}
+
+impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
+    fn render(
+        &self,
+        context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
+        content_area: &ContentArea,
+    ) {
+        if let Some(renderer) = context.frontend.renderer() {
+            let scale = renderer.scale();
+            let bounds = content_area.content_bounds();
+
+            let mut y = Length::default();
+            let prepared = context
+                .state
+                .prepared_text(renderer, content_area.size.content);
+            for paragraph in &prepared {
+                y += paragraph.render::<TextColor, _>(
+                    renderer,
+                    Point2D::new(bounds.origin.x, bounds.origin.y + y.get()),
+                    true,
+                );
+            }
+            context.state.prepared = Some(prepared);
+
+            if let Some(end) = context.state.cursor.end {
+                let selection_start = context.state.cursor.start.min(end);
+                let selection_end = context.state.cursor.start.max(end);
+                if let Some(start_position) = context
+                    .state
+                    .character_rect_for_position(renderer, selection_start)
+                {
+                    if let Some(end_position) = context
+                        .state
+                        .character_rect_for_position(renderer, selection_end)
+                    {
+                        if start_position.max_y() <= end_position.min_y() {
+                            // Multi-line
+                            // First line is start_position -> end of bounds
+                            let mut area = start_position.translate(bounds.origin.to_vector());
+                            area.size.width = bounds.size.width - start_position.origin.x;
+                            // TODO change to a SelectionColor component.
+                            renderer.fill_rect(&area, Color::new(1., 0., 0., 0.3));
+                            if start_position.max_y() < end_position.min_y() {
+                                // Draw a solid block for all the inner lines
+                                renderer.fill_rect(
+                                    &Rect::new(
+                                        Point2D::new(0., start_position.max_y()),
+                                        Size2D::new(
+                                            bounds.size.width,
+                                            end_position.min_y() - start_position.max_y(),
+                                        ),
+                                    )
+                                    .translate(bounds.origin.to_vector()),
+                                    Color::new(1., 0., 0., 0.3),
+                                );
+                            }
+                            // Last line is start of line -> start of end position
+                            renderer.fill_rect(
+                                &Rect::new(
+                                    Point2D::new(0., end_position.min_y()),
+                                    Size2D::new(end_position.origin.x, end_position.size.height),
+                                )
+                                .translate(bounds.origin.to_vector()),
+                                Color::new(1., 0., 0., 0.3),
+                            );
+                        } else {
+                            // Single-line
+                            let mut area = start_position;
+                            area.size.width = end_position.origin.x - start_position.origin.x;
+                            renderer.fill_rect(
+                                &area.translate(bounds.origin.to_vector()),
+                                Color::new(1., 0., 0., 0.3),
+                            );
+                        }
+                    }
+                }
+            } else if context.is_focused() && context.state.cursor.blink_state.visible {
+                if let Some(cursor_location) = context
+                    .state
+                    .character_rect_for_position(renderer, context.state.cursor.start)
+                {
+                    // No selection, draw a caret
+                    renderer.fill_rect(
+                        &Rect::new(
+                            bounds.origin,
+                            Size2D::from_lengths(
+                                Length::new(1.) / scale,
+                                Length::new(cursor_location.size.height),
+                            ),
+                        ),
+                        Color::RED,
+                    );
+                }
+            }
+        }
+    }
+
+    fn measure_content(
+        &self,
+        context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
+        constraints: Size2D<Option<f32>, Points>,
+    ) -> Size2D<f32, Points> {
+        context
+            .frontend
+            .renderer()
+            .map_or_else(Size2D::default, |renderer| {
+                let wrapped = wrap_text(
+                    &context.widget.value,
+                    context.style,
+                    renderer,
+                    Length::new(constraints.width.unwrap_or_else(|| renderer.size().width)),
+                );
+                wrapped.size()
+            })
+    }
+
+    fn mouse_down(
+        &self,
+        context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
+        button: MouseButton,
+        location: Point2D<f32, Points>,
+        area: &ContentArea,
+    ) -> EventStatus {
+        if button == MouseButton::Left {
+            context.focus();
+            context.state.cursor.blink_state.force_on();
+
+            let bounds = area.content_bounds();
+
+            if let Some(location) =
+                InputState::position_for_location(context, location - bounds.origin.to_vector())
+            {
+                context.state.cursor.start = location;
+                context.state.cursor.end = None;
+            }
+
+            context.frontend.set_needs_redraw();
+
+            EventStatus::Processed
+        } else {
+            EventStatus::Ignored
+        }
+    }
+
+    fn mouse_drag(
+        &self,
+        context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
+        button: MouseButton,
+        location: Point2D<f32, Points>,
+        area: &ContentArea,
+    ) {
+        if button == MouseButton::Left {
+            context.state.cursor.blink_state.force_on();
+            let bounds = area.content_bounds();
+            if let Some(location) =
+                InputState::position_for_location(context, location - bounds.origin.to_vector())
+            {
+                if location == context.state.cursor.start {
+                    if context.state.cursor.end != None {
+                        InputState::set_selection(context, context.state.cursor.start, None);
+                        context.frontend.set_needs_redraw();
+                    }
+                } else if context.state.cursor.end != Some(location) {
+                    context.state.cursor.end = Some(location);
+                    InputState::set_selection(context, context.state.cursor.start, Some(location));
+                    context.frontend.set_needs_redraw();
+                }
+            }
+        }
+    }
+}
+
+fn wrap_text<R: Renderer>(
+    label: &str,
+    style: &Style,
+    renderer: &R,
+    width: Length<f32, Points>,
+) -> PreparedText {
+    Text::span(label, style.clone()).wrap(
+        renderer,
+        TextWrap::MultiLine {
+            size: Size2D::from_lengths(width, Length::new(renderer.size().height)),
+        },
+        None,
+    )
+}
+
+#[derive(Debug)]
+pub struct InputState<R> {
+    text: RichText,
+    cursor: Cursor,
+    prepared: Option<Vec<PreparedText>>,
+    _renderer: PhantomData<R>,
+}
+
+impl<R: Renderer> Default for InputState<R> {
+    fn default() -> Self {
+        Self {
+            text: RichText::default(),
+            cursor: Cursor::default(),
+            prepared: None,
+            _renderer: PhantomData::default(),
+        }
+    }
+}
+
+type InputTransmogrifierContext<'a, R> =
+    TransmogrifierContext<'a, InputTransmogrifier, Rasterizer<R>>;
+
+impl<R: Renderer> InputState<R> {
+    // /// pastes text from the clipboard into the field
+    // ///
+    // /// If feature `clipboard` isn't enabled, this function will return Ok(()).
+    // #[allow(unused_variables)] // when clipboard is disabled, `context` is unused
+    // async fn paste(&mut self, context: &mut Context) -> KludgineResult<()> {
+    //     #[cfg(feature = "clipboard")]
+    //     {
+    //         let mut clipboard = arboard::Clipboard::new()?;
+
+    //         // Convert Result to Option to get rid of the Box<dyn Error> before the await
+    //         let pasted = clipboard.get_text().ok();
+    //         if let Some(pasted) = pasted {
+    //             self.replace_selection(&pasted, context);
+    //         }
+    //     }
+
+    //     Ok(())
+    // }
+
+    // /// copies the selected text to the clipboard.
+    // ///
+    // /// Returns whether text was successfully written to the clipboard. If
+    // /// feature `clipboard` isn't enabled, this function will always return
+    // /// Ok(false)
+    // async fn copy(&mut self) -> KludgineResult<bool> {
+    //     #[cfg(feature = "clipboard")]
+    //     {
+    //         let mut clipboard = arboard::Clipboard::new()?;
+
+    //         let selected = self.selected_string();
+
+    //         clipboard.set_text(selected)?;
+    //     }
+
+    //     return Ok(true);
+    // }
+
+    pub fn replace_selection(replacement: &str, context: &mut InputTransmogrifierContext<'_, R>) {
+        if context.state.cursor.end.is_some() {
+            let selection_start = context.state.cursor.selection_start();
+            let selection_end = context.state.cursor.selection_end();
+            context
+                .state
+                .text
+                .remove_range(selection_start..selection_end);
+            context.state.cursor.end = None;
+            context.state.cursor.start = selection_start;
+        }
+
+        context
+            .state
+            .text
+            .insert_str(context.state.cursor.start, replacement);
+        context.state.cursor.start.offset += replacement.len();
+        context.state.cursor.blink_state.force_on();
+
+        Self::notify_changed(context);
+        Self::notify_selection_changed(context);
+        context.frontend.set_needs_redraw();
+    }
+
+    pub fn selected_string(&self) -> String {
+        let mut copied_paragraphs = Vec::new();
+        self.text.for_each_in_range(
+            self.cursor.selection_start()..self.cursor.selection_end(),
+            |paragraph, relative_range| {
+                let mut span_strings = Vec::new();
+                paragraph.for_each_in_range(relative_range, |span, relative_range| {
+                    span_strings.push(span.text()[relative_range].to_string());
+                });
+                copied_paragraphs.push(span_strings.join(""));
+            },
+        );
+        copied_paragraphs.join("\n")
+    }
+
+    fn prepared_text(&self, renderer: &R, constraints: Size2D<f32, Points>) -> Vec<PreparedText> {
+        self.text.prepare(
+            renderer,
+            TextWrap::SingleLine {
+                width: Length::new(constraints.width),
+            },
+        )
+    }
+
+    fn position_for_location(
+        context: &mut InputTransmogrifierContext<'_, R>,
+        location: Point2D<f32, Points>,
+    ) -> Option<RichTextPosition> {
+        if let Some(prepared) = &context.state.prepared {
+            let mut y = Length::<f32, Points>::default();
+            let scale = context
+                .frontend
+                .renderer()
+                .map(|r| r.scale())
+                .unwrap_or_default();
+            for (paragraph_index, paragraph) in prepared.iter().enumerate() {
+                for line in &paragraph.lines {
+                    let line_bottom = y + Length::new(line.size().height) / scale;
+                    if location.y < line_bottom.get() {
+                        // Click location was within this line
+                        for span in &line.spans {
+                            let span_end = span.location() + span.metrics().width;
+                            if !span.text().is_empty() && location.x < span_end.get() {
+                                // Click was within this span
+                                todo!()
+                                // let relative_pixels = (location.x() - x) * scale;
+                                // for info in span.data.glyphs.iter() {
+                                //     if relative_pixels <= info.location().x() + info.width() {
+                                //         return Some(RichTextPosition {
+                                //             paragraph: paragraph_index,
+                                //             offset: info.source_offset,
+                                //         });
+                                //     }
+                                // }
+
+                                // return Some(RichTextPosition {
+                                //     paragraph: paragraph_index,
+                                //     offset: span.data.glyphs.last().unwrap().source_offset,
+                                // });
+                            }
+                        }
+                        // Didn't match a span, return the last character of the line
+                        if let Some(span) = line.spans.last() {
+                            // Didn't match within the span, put it at the end of the span
+                            return Some(RichTextPosition {
+                                paragraph: paragraph_index,
+                                offset: span.offset() + span.text().chars().count(),
+                            });
+                        }
+                    }
+
+                    y = line_bottom;
+                }
+            }
+        }
+
+        None
+    }
+
+    fn character_rect_for_position(
+        &self,
+        renderer: &R,
+        position: RichTextPosition,
+    ) -> Option<Rect<f32, Points>> {
+        let mut last_location = None;
+        if let Some(prepared) = &self.prepared {
+            let prepared = prepared.get(position.paragraph)?;
+            let mut line_top = Length::default();
+            for line in &prepared.lines {
+                let line_height = line.height();
+                for span in &line.spans {
+                    if !span.text().is_empty() {
+                        // TODO measure this subset of text.
+                        // let last_glyph = span.data.glyphs.last().unwrap();
+                        // if position.offset <= last_glyph.source_offset {
+                        //     // Return a box of the width of the last character with the start of the character at the origin
+                        //     for info in span.data.glyphs.iter() {
+                        //         if info.source_offset >= position.offset {
+                        //             return Some(Rect::new(
+                        //                 Point::from_lengths(
+                        //                     (span.location.x() + info.location().x()) / scale,
+                        //                     line_top + span.location.y() / scale,
+                        //                 ),
+                        //                 Size::from_lengths(info.width() / scale, line_height),
+                        //             ));
+                        //         }
+                        //     }
+                        // }
+                        // last_location = Some(Rect::new(
+                        //     Point2D::from_lengths(
+                        //         (span.location()
+                        //             + last_glyph.location().x()
+                        //             + last_glyph.width())
+                        //             / scale,
+                        //         line_top + span.location.y() / scale,
+                        //     ),
+                        //     Size::from_lengths(Default::default(), line_height),
+                        // ));
+                    }
+                }
+                line_top += line_height;
+            }
+        }
+        last_location
+    }
+
+    fn notify_changed(context: &mut InputTransmogrifierContext<'_, R>) {
+        context.widget.value = context.state.text.to_string();
+        context.widget.changed.invoke(());
+    }
+
+    fn notify_selection_changed(context: &mut InputTransmogrifierContext<'_, R>) {
+        let selection_start = context
+            .state
+            .text
+            .character_offset_of(context.state.cursor.selection_start());
+        context.widget.selection_start = selection_start;
+        let selection_end = context
+            .state
+            .text
+            .character_offset_of(context.state.cursor.selection_end());
+        if selection_start == selection_end {
+            context.widget.selection_end = None;
+        } else {
+            context.widget.selection_end = Some(selection_end);
+        }
+        context.widget.selection_changed.invoke(());
+    }
+
+    pub fn set_selection(
+        context: &mut InputTransmogrifierContext<'_, R>,
+        selection_start: RichTextPosition,
+        end: Option<RichTextPosition>,
+    ) {
+        context.state.cursor.start = selection_start;
+        context.state.cursor.end = end;
+        Self::notify_selection_changed(context);
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Cursor {
+    pub blink_state: BlinkState,
+    pub start: RichTextPosition,
+    pub end: Option<RichTextPosition>,
+}
+
+impl Cursor {
+    pub fn selection_start(&self) -> RichTextPosition {
+        self.end.map_or(self.start, |end| self.start.min(end))
+    }
+
+    pub fn selection_end(&self) -> RichTextPosition {
+        self.end.map_or(self.start, |end| self.start.max(end))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BlinkState {
+    pub visible: bool,
+    pub change_at: Instant,
+}
+
+impl Default for BlinkState {
+    fn default() -> Self {
+        Self {
+            visible: true,
+            change_at: Self::next_blink(),
+        }
+    }
+}
+
+impl BlinkState {
+    pub fn next_blink() -> Instant {
+        let now = Instant::now();
+        now.checked_add(Duration::from_millis(CURSOR_BLINK_MS))
+            .unwrap_or(now)
+    }
+
+    pub fn force_on(&mut self) {
+        self.visible = true;
+        self.change_at = Self::next_blink();
+    }
+
+    pub fn update(&mut self) -> Option<Duration> {
+        let now = Instant::now();
+        if self.change_at < now {
+            self.visible = !self.visible;
+            self.change_at = Self::next_blink();
+        }
+
+        self.change_at.checked_duration_since(now)
+    }
+}

--- a/widgets/src/input/rasterizer.rs
+++ b/widgets/src/input/rasterizer.rs
@@ -4,6 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 use arboard::Clipboard;
 use gooey_core::{
     figures::{Displayable, Figure, Point, Rect, Rectlike, Size, SizedRect},
@@ -320,6 +321,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
                         }
                         true
                     }
+                    #[cfg(not(target_arch = "wasm32"))]
                     VirtualKeyCode::V => {
                         if context.frontend.keyboard_modifiers().primary() {
                             InputState::paste(context);
@@ -328,6 +330,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
                             false
                         }
                     }
+                    #[cfg(not(target_arch = "wasm32"))]
                     VirtualKeyCode::X | VirtualKeyCode::C => {
                         if context.frontend.keyboard_modifiers().primary()
                             && InputState::copy(context)
@@ -372,6 +375,7 @@ pub struct InputState<R> {
     text: RichText,
     cursor: Cursor,
     prepared: Option<Vec<PreparedText>>,
+    #[cfg(not(target_arch = "wasm32"))]
     clipboard: Option<Clipboard>,
     _renderer: PhantomData<R>,
 }
@@ -389,6 +393,7 @@ impl<R: Renderer> Debug for InputState<R> {
 impl<R: Renderer> Default for InputState<R> {
     fn default() -> Self {
         Self {
+            #[cfg(not(target_arch = "wasm32"))]
             clipboard: Clipboard::new().ok(),
             text: RichText::default(),
             cursor: Cursor::default(),
@@ -402,6 +407,7 @@ type InputTransmogrifierContext<'a, R> =
     TransmogrifierContext<'a, InputTransmogrifier, Rasterizer<R>>;
 
 impl<R: Renderer> InputState<R> {
+    #[cfg(not(target_arch = "wasm32"))]
     fn paste(context: &mut InputTransmogrifierContext<'_, R>) {
         if let Some(clipboard) = &mut context.state.clipboard {
             // Convert Result to Option to get rid of the Box<dyn Error> before the await
@@ -417,6 +423,7 @@ impl<R: Renderer> InputState<R> {
     /// Returns whether text was successfully written to the clipboard. If
     /// feature `clipboard` isn't enabled, this function will always return
     /// Ok(false)
+    #[cfg(not(target_arch = "wasm32"))]
     fn copy(context: &mut InputTransmogrifierContext<'_, R>) -> bool {
         let selected = context.state.selected_string();
         context

--- a/widgets/src/input/rasterizer.rs
+++ b/widgets/src/input/rasterizer.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use gooey_core::{
-    figures::{Figure, One, Point, Rectlike, Scale, Size, SizedRect, Vectorlike},
+    figures::{Figure, One, Point, Rect, Rectlike, Scale, Size, SizedRect, Vectorlike},
     styles::{Color, Style, TextColor},
     Points, Transmogrifier, TransmogrifierContext,
 };
@@ -61,7 +61,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
     ) {
         if let Some(renderer) = context.frontend.renderer() {
             let scale = renderer.scale();
-            let bounds = content_area.content_bounds();
+            let bounds = content_area.content_bounds().as_sized();
 
             let mut y = Figure::<f32, Points>::default();
             let prepared = context
@@ -97,11 +97,11 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
                                 .as_sized();
                             area.size.width = bounds.size.width - start_position.origin.x;
                             // TODO change to a SelectionColor component.
-                            renderer.fill_rect(&area, Color::new(1., 0., 0., 0.3));
+                            renderer.fill_rect(&area.as_rect(), Color::new(1., 0., 0., 0.3));
                             if start_position.extent.y < end_position.origin.y {
                                 // Draw a solid block for all the inner lines
                                 renderer.fill_rect(
-                                    &SizedRect::new(
+                                    &Rect::sized(
                                         Point::new(0., start_position.extent.y),
                                         Size::from_figures(
                                             bounds.size.width(),
@@ -114,7 +114,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
                             }
                             // Last line is start of line -> start of end position
                             renderer.fill_rect(
-                                &SizedRect::new(
+                                &Rect::sized(
                                     Point::new(0., end_position.origin.y),
                                     Size::from_figures(
                                         end_position.origin.x(),
@@ -129,7 +129,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
                             let mut area = start_position.as_sized();
                             area.size.width = end_position.origin.x - start_position.origin.x;
                             renderer.fill_rect(
-                                &area.translate(bounds.origin.to_vector()),
+                                &area.translate(bounds.origin.to_vector()).as_rect(),
                                 Color::new(1., 0., 0., 0.3),
                             );
                         }
@@ -142,7 +142,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
                 {
                     // No selection, draw a caret
                     renderer.fill_rect(
-                        &SizedRect::new(
+                        &Rect::sized(
                             bounds.origin,
                             Size::from_figures(
                                 Figure::new(1.) / scale,
@@ -189,7 +189,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
             let bounds = area.content_bounds();
 
             if let Some(location) =
-                InputState::position_for_location(context, location - bounds.origin.to_vector())
+                InputState::position_for_location(context, location - bounds.origin().to_vector())
             {
                 context.state.cursor.start = location;
                 context.state.cursor.end = None;
@@ -214,7 +214,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
             context.state.cursor.blink_state.force_on();
             let bounds = area.content_bounds();
             if let Some(location) =
-                InputState::position_for_location(context, location - bounds.origin.to_vector())
+                InputState::position_for_location(context, location - bounds.origin().to_vector())
             {
                 if location == context.state.cursor.start {
                     if context.state.cursor.end != None {

--- a/widgets/src/input/rasterizer.rs
+++ b/widgets/src/input/rasterizer.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use gooey_core::{
-    figures::{Figure, One, Point, Rect, Rectlike, Scale, Size, SizedRect, Vectorlike},
+    figures::{Figure, One, Point, Rect, Rectlike, Scale, Size, SizedRect},
     styles::{Color, Style, TextColor},
     Points, Transmogrifier, TransmogrifierContext,
 };
@@ -92,9 +92,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
                         if start_position.extent.y <= end_position.origin.y {
                             // Multi-line
                             // First line is start_position -> end of bounds
-                            let mut area = start_position
-                                .translate(bounds.origin.to_vector())
-                                .as_sized();
+                            let mut area = start_position.translate(bounds.origin).as_sized();
                             area.size.width = bounds.size.width - start_position.origin.x;
                             // TODO change to a SelectionColor component.
                             renderer.fill_rect(&area.as_rect(), Color::new(1., 0., 0., 0.3));
@@ -108,7 +106,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
                                             end_position.origin.y() - start_position.extent.y(),
                                         ),
                                     )
-                                    .translate(bounds.origin.to_vector()),
+                                    .translate(bounds.origin),
                                     Color::new(1., 0., 0., 0.3),
                                 );
                             }
@@ -121,7 +119,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
                                         end_position.height(),
                                     ),
                                 )
-                                .translate(bounds.origin.to_vector()),
+                                .translate(bounds.origin),
                                 Color::new(1., 0., 0., 0.3),
                             );
                         } else {
@@ -129,7 +127,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
                             let mut area = start_position.as_sized();
                             area.size.width = end_position.origin.x - start_position.origin.x;
                             renderer.fill_rect(
-                                &area.translate(bounds.origin.to_vector()).as_rect(),
+                                &area.translate(bounds.origin).as_rect(),
                                 Color::new(1., 0., 0., 0.3),
                             );
                         }
@@ -189,7 +187,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
             let bounds = area.content_bounds();
 
             if let Some(location) =
-                InputState::position_for_location(context, location - bounds.origin().to_vector())
+                InputState::position_for_location(context, location - bounds.origin())
             {
                 context.state.cursor.start = location;
                 context.state.cursor.end = None;
@@ -214,7 +212,7 @@ impl<R: Renderer> WidgetRasterizer<R> for InputTransmogrifier {
             context.state.cursor.blink_state.force_on();
             let bounds = area.content_bounds();
             if let Some(location) =
-                InputState::position_for_location(context, location - bounds.origin().to_vector())
+                InputState::position_for_location(context, location - bounds.origin())
             {
                 if location == context.state.cursor.start {
                     if context.state.cursor.end != None {

--- a/widgets/src/input/rasterizer.rs
+++ b/widgets/src/input/rasterizer.rs
@@ -6,7 +6,7 @@ use std::{
 use gooey_core::{
     euclid::{Length, Point2D, Rect, Size2D},
     styles::{Color, Style, TextColor},
-    Context, Points, Transmogrifier, TransmogrifierContext,
+    Points, Transmogrifier, TransmogrifierContext,
 };
 use gooey_rasterizer::{
     winit::event::MouseButton, ContentArea, EventStatus, Rasterizer, Renderer,

--- a/widgets/src/label/browser.rs
+++ b/widgets/src/label/browser.rs
@@ -68,7 +68,7 @@ fn text_to_html(text: &Text, target: &HtmlElement, element_style: &Style, theme:
 
 fn span_to_html(span: &Span, target: &HtmlElement, element_style: &Style, theme: SystemTheme) {
     let element = create_element::<HtmlSpanElement>("span");
-    element.set_inner_text(&span.text);
+    element.set_inner_text(span.text());
     let mut style = String::new();
     if let Some(color) = span
         .style

--- a/widgets/src/label/rasterizer.rs
+++ b/widgets/src/label/rasterizer.rs
@@ -1,7 +1,7 @@
 use gooey_core::{
     figures::{Figure, Size},
     styles::Style,
-    Points, Transmogrifier, TransmogrifierContext,
+    Scaled, Transmogrifier, TransmogrifierContext,
 };
 use gooey_rasterizer::{ContentArea, Rasterizer, Renderer, WidgetRasterizer};
 use gooey_text::{prepared::PreparedText, wrap::TextWrap, Text};
@@ -47,8 +47,8 @@ impl<R: Renderer> WidgetRasterizer<R> for LabelTransmogrifier {
     fn measure_content(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
-    ) -> Size<f32, Points> {
+        constraints: Size<Option<f32>, Scaled>,
+    ) -> Size<f32, Scaled> {
         context
             .frontend
             .renderer()
@@ -68,7 +68,7 @@ fn wrap_text<R: Renderer>(
     label: &Text,
     style: &Style,
     renderer: &R,
-    width: Figure<f32, Points>,
+    width: Figure<f32, Scaled>,
 ) -> PreparedText {
     label.wrap(
         renderer,

--- a/widgets/src/label/rasterizer.rs
+++ b/widgets/src/label/rasterizer.rs
@@ -1,5 +1,5 @@
 use gooey_core::{
-    euclid::{Length, Size2D},
+    figures::{Figure, Size},
     styles::Style,
     Points, Transmogrifier, TransmogrifierContext,
 };
@@ -34,7 +34,7 @@ impl<R: Renderer> WidgetRasterizer<R> for LabelTransmogrifier {
                 &context.widget.label,
                 context.style,
                 renderer,
-                Length::new(content_area.size.content.width),
+                Figure::new(content_area.size.content.width),
             );
             wrapped.render_within::<LabelColor, _>(
                 renderer,
@@ -47,17 +47,17 @@ impl<R: Renderer> WidgetRasterizer<R> for LabelTransmogrifier {
     fn measure_content(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size2D<Option<f32>, Points>,
-    ) -> Size2D<f32, Points> {
+        constraints: Size<Option<f32>, Points>,
+    ) -> Size<f32, Points> {
         context
             .frontend
             .renderer()
-            .map_or_else(Size2D::default, |renderer| {
+            .map_or_else(Size::default, |renderer| {
                 let wrapped = wrap_text(
                     &context.widget.label,
                     context.style,
                     renderer,
-                    Length::new(constraints.width.unwrap_or_else(|| renderer.size().width)),
+                    Figure::new(constraints.width.unwrap_or_else(|| renderer.size().width)),
                 );
                 wrapped.size()
             })
@@ -68,12 +68,12 @@ fn wrap_text<R: Renderer>(
     label: &Text,
     style: &Style,
     renderer: &R,
-    width: Length<f32, Points>,
+    width: Figure<f32, Points>,
 ) -> PreparedText {
     label.wrap(
         renderer,
         TextWrap::MultiLine {
-            size: Size2D::from_lengths(width, Length::new(renderer.size().height)),
+            size: Size::from_figures(width, Figure::new(renderer.size().height)),
         },
         Some(style),
     )

--- a/widgets/src/label/rasterizer.rs
+++ b/widgets/src/label/rasterizer.rs
@@ -36,7 +36,11 @@ impl<R: Renderer> WidgetRasterizer<R> for LabelTransmogrifier {
                 renderer,
                 Length::new(content_area.size.content.width),
             );
-            wrapped.render_within::<LabelColor, _>(renderer, content_area.bounds(), context.style);
+            wrapped.render_within::<LabelColor, _>(
+                renderer,
+                content_area.content_bounds(),
+                context.style,
+            );
         }
     }
 

--- a/widgets/src/layout.rs
+++ b/widgets/src/layout.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug};
+use std::{collections::HashMap, fmt::Debug, ops::Deref};
 
 use gooey_core::{
     figures::{Figure, Size},
@@ -158,6 +158,14 @@ impl<K: Key> ChildrenMap<K> {
 pub struct LayoutChild {
     pub registration: WidgetRegistration,
     pub layout: WidgetLayout,
+}
+
+impl Deref for LayoutChild {
+    type Target = WidgetLayout;
+
+    fn deref(&self) -> &WidgetLayout {
+        &self.layout
+    }
 }
 
 impl<K: Key, S: KeyedStorage<K>> Builder<K, S> {
@@ -325,7 +333,6 @@ impl WidgetLayoutBuilder {
     pub const fn fill_width(mut self) -> Self {
         self.layout.left = Dimension::zero();
         self.layout.right = Dimension::zero();
-        self.layout.width = Dimension::percent(1.);
         self
     }
 
@@ -346,7 +353,6 @@ impl WidgetLayoutBuilder {
     pub const fn fill_height(mut self) -> Self {
         self.layout.top = Dimension::zero();
         self.layout.bottom = Dimension::zero();
-        self.layout.height = Dimension::percent(1.);
         self
     }
 

--- a/widgets/src/layout.rs
+++ b/widgets/src/layout.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt::Debug};
 
 use gooey_core::{
-    euclid::{Length, Size2D},
+    figures::{Figure, Size},
     styles::Surround,
     AnySendSync, Context, Key, KeyedStorage, Points, RelatedStorage, StyledWidget, Widget,
     WidgetId, WidgetRegistration, WidgetStorage,
@@ -236,50 +236,44 @@ impl WidgetLayout {
     }
 
     #[must_use]
-    pub fn left_in_points(&self, content_size: Size2D<f32, Points>) -> Option<Length<f32, Points>> {
-        self.left.length(Length::new(content_size.width))
+    pub fn left_in_points(&self, content_size: Size<f32, Points>) -> Option<Figure<f32, Points>> {
+        self.left.length(Figure::new(content_size.width))
     }
 
     #[must_use]
-    pub fn right_in_points(
-        &self,
-        content_size: Size2D<f32, Points>,
-    ) -> Option<Length<f32, Points>> {
-        self.right.length(Length::new(content_size.width))
+    pub fn right_in_points(&self, content_size: Size<f32, Points>) -> Option<Figure<f32, Points>> {
+        self.right.length(Figure::new(content_size.width))
     }
 
     #[must_use]
-    pub fn top_in_points(&self, content_size: Size2D<f32, Points>) -> Option<Length<f32, Points>> {
-        self.top.length(Length::new(content_size.height))
+    pub fn top_in_points(&self, content_size: Size<f32, Points>) -> Option<Figure<f32, Points>> {
+        self.top.length(Figure::new(content_size.height))
     }
 
     #[must_use]
-    pub fn bottom_in_points(
-        &self,
-        content_size: Size2D<f32, Points>,
-    ) -> Option<Length<f32, Points>> {
-        self.bottom.length(Length::new(content_size.height))
+    pub fn bottom_in_points(&self, content_size: Size<f32, Points>) -> Option<Figure<f32, Points>> {
+        self.bottom.length(Figure::new(content_size.height))
     }
 
     #[must_use]
-    pub fn width_in_points(&self, content_size: Size2D<f32, Points>) -> Length<f32, Points> {
+    pub fn width_in_points(&self, content_size: Size<f32, Points>) -> Figure<f32, Points> {
         self.width
-            .length(Length::new(content_size.width))
-            .unwrap_or_else(|| Length::new(content_size.width))
+            .length(Figure::new(content_size.width))
+            .unwrap_or_else(|| Figure::new(content_size.width))
     }
 
     #[must_use]
-    pub fn height_in_points(&self, content_size: Size2D<f32, Points>) -> Length<f32, Points> {
+    pub fn height_in_points(&self, content_size: Size<f32, Points>) -> Figure<f32, Points> {
         self.height
-            .length(Length::new(content_size.height))
-            .unwrap_or_else(|| Length::new(content_size.height))
+            .length(Figure::new(content_size.height))
+            .unwrap_or_else(|| Figure::new(content_size.height))
     }
 
     #[must_use]
     pub fn surround_in_points(
         &self,
-        content_size: Size2D<f32, Points>,
-    ) -> Surround<Length<f32, Points>> {
+        content_size: Size<f32, Points>,
+    ) -> Surround<Figure<f32, Points>> {
         Surround {
             left: self.left_in_points(content_size),
             top: self.top_in_points(content_size),
@@ -289,8 +283,8 @@ impl WidgetLayout {
     }
 
     #[must_use]
-    pub fn size_in_points(&self, content_size: Size2D<f32, Points>) -> Size2D<f32, Points> {
-        Size2D::from_lengths(
+    pub fn size_in_points(&self, content_size: Size<f32, Points>) -> Size<f32, Points> {
+        Size::from_figures(
             self.width_in_points(content_size),
             self.height_in_points(content_size),
         )
@@ -392,7 +386,7 @@ impl LayoutChildren for Layout {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Dimension {
     Auto,
-    Exact(Length<f32, Points>),
+    Exact(Figure<f32, Points>),
     Percent(f32),
 }
 
@@ -405,12 +399,12 @@ impl Default for Dimension {
 impl Dimension {
     #[must_use]
     pub const fn zero() -> Self {
-        Self::Exact(Length::new(0.))
+        Self::Exact(Figure::new(0.))
     }
 
     #[must_use]
     pub const fn exact(length: f32) -> Self {
-        Self::Exact(Length::new(length))
+        Self::Exact(Figure::new(length))
     }
 
     #[must_use]
@@ -419,7 +413,7 @@ impl Dimension {
     }
 
     #[must_use]
-    pub fn length(self, content_length: Length<f32, Points>) -> Option<Length<f32, Points>> {
+    pub fn length(self, content_length: Figure<f32, Points>) -> Option<Figure<f32, Points>> {
         match self {
             Dimension::Auto => None,
             Dimension::Exact(measurement) => Some(measurement),
@@ -428,8 +422,8 @@ impl Dimension {
     }
 }
 
-impl From<Length<f32, Points>> for Dimension {
-    fn from(length: Length<f32, Points>) -> Self {
+impl From<Figure<f32, Points>> for Dimension {
+    fn from(length: Figure<f32, Points>) -> Self {
         Self::Exact(length)
     }
 }

--- a/widgets/src/layout.rs
+++ b/widgets/src/layout.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt::Debug};
 use gooey_core::{
     figures::{Figure, Size},
     styles::Surround,
-    AnySendSync, Context, Key, KeyedStorage, Points, RelatedStorage, StyledWidget, Widget,
+    AnySendSync, Context, Key, KeyedStorage, RelatedStorage, Scaled, StyledWidget, Widget,
     WidgetId, WidgetRegistration, WidgetStorage,
 };
 
@@ -236,34 +236,34 @@ impl WidgetLayout {
     }
 
     #[must_use]
-    pub fn left_in_points(&self, content_size: Size<f32, Points>) -> Option<Figure<f32, Points>> {
+    pub fn left_in_points(&self, content_size: Size<f32, Scaled>) -> Option<Figure<f32, Scaled>> {
         self.left.length(Figure::new(content_size.width))
     }
 
     #[must_use]
-    pub fn right_in_points(&self, content_size: Size<f32, Points>) -> Option<Figure<f32, Points>> {
+    pub fn right_in_points(&self, content_size: Size<f32, Scaled>) -> Option<Figure<f32, Scaled>> {
         self.right.length(Figure::new(content_size.width))
     }
 
     #[must_use]
-    pub fn top_in_points(&self, content_size: Size<f32, Points>) -> Option<Figure<f32, Points>> {
+    pub fn top_in_points(&self, content_size: Size<f32, Scaled>) -> Option<Figure<f32, Scaled>> {
         self.top.length(Figure::new(content_size.height))
     }
 
     #[must_use]
-    pub fn bottom_in_points(&self, content_size: Size<f32, Points>) -> Option<Figure<f32, Points>> {
+    pub fn bottom_in_points(&self, content_size: Size<f32, Scaled>) -> Option<Figure<f32, Scaled>> {
         self.bottom.length(Figure::new(content_size.height))
     }
 
     #[must_use]
-    pub fn width_in_points(&self, content_size: Size<f32, Points>) -> Figure<f32, Points> {
+    pub fn width_in_points(&self, content_size: Size<f32, Scaled>) -> Figure<f32, Scaled> {
         self.width
             .length(Figure::new(content_size.width))
             .unwrap_or_else(|| Figure::new(content_size.width))
     }
 
     #[must_use]
-    pub fn height_in_points(&self, content_size: Size<f32, Points>) -> Figure<f32, Points> {
+    pub fn height_in_points(&self, content_size: Size<f32, Scaled>) -> Figure<f32, Scaled> {
         self.height
             .length(Figure::new(content_size.height))
             .unwrap_or_else(|| Figure::new(content_size.height))
@@ -272,8 +272,8 @@ impl WidgetLayout {
     #[must_use]
     pub fn surround_in_points(
         &self,
-        content_size: Size<f32, Points>,
-    ) -> Surround<Figure<f32, Points>> {
+        content_size: Size<f32, Scaled>,
+    ) -> Surround<Figure<f32, Scaled>> {
         Surround {
             left: self.left_in_points(content_size),
             top: self.top_in_points(content_size),
@@ -283,7 +283,7 @@ impl WidgetLayout {
     }
 
     #[must_use]
-    pub fn size_in_points(&self, content_size: Size<f32, Points>) -> Size<f32, Points> {
+    pub fn size_in_points(&self, content_size: Size<f32, Scaled>) -> Size<f32, Scaled> {
         Size::from_figures(
             self.width_in_points(content_size),
             self.height_in_points(content_size),
@@ -386,7 +386,7 @@ impl LayoutChildren for Layout {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Dimension {
     Auto,
-    Exact(Figure<f32, Points>),
+    Exact(Figure<f32, Scaled>),
     Percent(f32),
 }
 
@@ -413,7 +413,7 @@ impl Dimension {
     }
 
     #[must_use]
-    pub fn length(self, content_length: Figure<f32, Points>) -> Option<Figure<f32, Points>> {
+    pub fn length(self, content_length: Figure<f32, Scaled>) -> Option<Figure<f32, Scaled>> {
         match self {
             Dimension::Auto => None,
             Dimension::Exact(measurement) => Some(measurement),
@@ -422,8 +422,8 @@ impl Dimension {
     }
 }
 
-impl From<Figure<f32, Points>> for Dimension {
-    fn from(length: Figure<f32, Points>) -> Self {
+impl From<Figure<f32, Scaled>> for Dimension {
+    fn from(length: Figure<f32, Scaled>) -> Self {
         Self::Exact(length)
     }
 }

--- a/widgets/src/layout/rasterizer.rs
+++ b/widgets/src/layout/rasterizer.rs
@@ -33,9 +33,7 @@ impl<R: Renderer> WidgetRasterizer<R> for LayoutTransmogrifier {
                 |transmogrifier, mut child_context| {
                     transmogrifier.render_within(
                         &mut child_context,
-                        child_bounds
-                            .translate(content_area.location.to_vector())
-                            .as_rect(),
+                        child_bounds.translate(content_area.location).as_rect(),
                         context.style,
                     );
                 },

--- a/widgets/src/layout/rasterizer.rs
+++ b/widgets/src/layout/rasterizer.rs
@@ -1,10 +1,12 @@
+use std::ops::Deref;
+
 use gooey_core::{
     figures::{Figure, Point, Rectlike, Size, SizedRect, Vector, Vectorlike},
     Scaled, Transmogrifier, TransmogrifierContext,
 };
 use gooey_rasterizer::{ContentArea, Rasterizer, Renderer, WidgetRasterizer};
 
-use super::LayoutChild;
+use super::{LayoutChild, WidgetLayout};
 use crate::layout::{Layout, LayoutTransmogrifier};
 
 impl<R: Renderer> Transmogrifier<Rasterizer<R>> for LayoutTransmogrifier {
@@ -63,57 +65,200 @@ impl<R: Renderer> WidgetRasterizer<R> for LayoutTransmogrifier {
 fn for_each_measured_widget<R: Renderer, F: FnMut(&LayoutChild, SizedRect<f32, Scaled>)>(
     context: &TransmogrifierContext<'_, LayoutTransmogrifier, Rasterizer<R>>,
     constraints: Size<f32, Scaled>,
+    callback: F,
+) {
+    for_each_widget(
+        context.widget.children.layout_children(),
+        constraints,
+        |child| {
+            let layout_surround = child.layout.surround_in_points(constraints);
+            let layout_max_size = child
+                .layout
+                .size_in_points(constraints)
+                .min(&(constraints - layout_surround.minimum_size()));
+            // Constrain the child to whatever remains after the left/right/top/bottom
+            // measurements
+            let child_constraints =
+                Size::new(Some(layout_max_size.width), Some(layout_max_size.height));
+            context
+                .frontend
+                .with_transmogrifier(
+                    child.registration.id(),
+                    |transmogrifier, mut child_context| {
+                        transmogrifier
+                            .content_size(&mut child_context, child_constraints)
+                            .total_size()
+                    },
+                )
+                .expect("unknown transmogrifier")
+        },
+        callback,
+    );
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn for_each_widget<
+    C: Deref<Target = WidgetLayout>,
+    F: FnMut(&C, SizedRect<f32, Scaled>),
+    W: Fn(&C) -> Size<f32, Scaled>,
+>(
+    // context: &TransmogrifierContext<'_, LayoutTransmogrifier, Rasterizer<R>>,
+    children: Vec<C>,
+    constraints: Size<f32, Scaled>,
+    child_measurer: W,
     mut callback: F,
 ) {
-    for child in context.widget.children.layout_children() {
-        let layout_surround = child.layout.surround_in_points(constraints);
-        let layout_max_size = child
-            .layout
-            .size_in_points(constraints)
-            .min(&(constraints - layout_surround.minimum_size()));
-
-        // Constrain the child to whatever remains after the left/right/top/bottom
-        // measurements
-        let child_constraints =
-            Size::new(Some(layout_max_size.width), Some(layout_max_size.height));
+    for child in children {
+        let layout_surround = child.surround_in_points(constraints);
 
         // Ask the child to measure
-        let child_size = context
-            .frontend
-            .with_transmogrifier(
-                child.registration.id(),
-                |transmogrifier, mut child_context| {
-                    transmogrifier
-                        .content_size(&mut child_context, child_constraints)
-                        .total_size()
-                },
-            )
-            .expect("unknown transmogrifier");
+        let child_size = child_measurer(&child);
 
         // If the layout has an explicit width/height, we should return it if it's a
         // value larger than what the child reported
-        let child_size = child_size.max(&layout_max_size);
+        let child_size = Size::from_figures(
+            child
+                .width
+                .length(constraints.width())
+                .unwrap_or_else(|| child_size.width()),
+            child
+                .height
+                .length(constraints.height())
+                .unwrap_or_else(|| child_size.height()),
+        );
         let remaining_size = constraints - child_size;
-        // If either top or left are Auto, we look at bottom or right,
-        // respectively. If the corresponding dimension is also Auto, we divide
-        // the remaining amount in two. If the other dimension is specified,
-        // however, we subtract its measurement from the remaining value and use
-        // it as top/left.
-        let child_left = layout_surround.left.unwrap_or_else(|| {
-            let remaining_width = Figure::new(remaining_size.width);
-            layout_surround
-                .right
-                .map_or_else(|| remaining_width / 2., |right| remaining_width - right)
-        });
-        let child_top = layout_surround.top.unwrap_or_else(|| {
-            let remaining_height = Figure::new(remaining_size.height);
-            layout_surround
-                .bottom
-                .map_or_else(|| remaining_height / 2., |bottom| remaining_height - bottom)
-        });
+        let (left, width) = calculate_origin_length(
+            layout_surround.left,
+            layout_surround.right,
+            child_size.width(),
+            remaining_size.width(),
+        );
+        let (top, height) = calculate_origin_length(
+            layout_surround.top,
+            layout_surround.bottom,
+            child_size.height(),
+            remaining_size.height(),
+        );
         callback(
             &child,
-            SizedRect::new(Point::from_figures(child_left, child_top), child_size),
+            SizedRect::new(
+                Point::from_figures(left, top),
+                Size::from_figures(width, height).max(&Size::default()),
+            ),
+        );
+    }
+}
+
+fn calculate_origin_length(
+    origin: Option<Figure<f32, Scaled>>,
+    extent: Option<Figure<f32, Scaled>>,
+    measured: Figure<f32, Scaled>,
+    remaining: Figure<f32, Scaled>,
+) -> (Figure<f32, Scaled>, Figure<f32, Scaled>) {
+    match (origin, extent) {
+        (Some(origin), Some(extent)) => {
+            // Length is calculated
+            (origin, measured + remaining - extent - origin)
+        }
+        (Some(top), None) => {
+            // Extent would be calculated, but doesn't need to be
+            (top, measured)
+        }
+        (None, Some(bottom)) => {
+            // Extent is calculated
+            (remaining - bottom, measured)
+        }
+        (None, None) => (Figure::default(), measured),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Deref;
+
+    use gooey_core::figures::{Approx, Point, Scaled, Size, SizedRect};
+
+    use crate::layout::{rasterizer::for_each_widget, Dimension, WidgetLayout};
+
+    struct TestCase {
+        layout: WidgetLayout,
+        result: SizedRect<f32, Scaled>,
+    }
+
+    impl Deref for TestCase {
+        type Target = WidgetLayout;
+
+        fn deref(&self) -> &WidgetLayout {
+            &self.layout
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "frontend-rasterizer")]
+    fn layout_tests() {
+        // Each test case will have a widget that returns a measurement of 30x20
+        // The constraints will be 100,90.
+        let widget_size = Size::new(30., 20.);
+        let cases = vec![
+            TestCase {
+                layout: WidgetLayout::default(),
+                result: SizedRect::new(Point::default(), widget_size),
+            },
+            TestCase {
+                layout: WidgetLayout::build()
+                    .left(Dimension::exact(10.))
+                    .top(Dimension::exact(20.))
+                    .finish(),
+                result: SizedRect::new(Point::new(10., 20.), widget_size),
+            },
+            TestCase {
+                layout: WidgetLayout::build()
+                    .right(Dimension::exact(10.))
+                    .bottom(Dimension::exact(20.))
+                    .finish(),
+                result: SizedRect::new(Point::new(60., 50.), widget_size),
+            },
+            TestCase {
+                layout: WidgetLayout::build()
+                    .left(Dimension::exact(10.))
+                    .top(Dimension::exact(20.))
+                    .width(Dimension::exact(40.))
+                    .height(Dimension::exact(30.))
+                    .finish(),
+                result: SizedRect::new(Point::new(10., 20.), Size::new(40., 30.)),
+            },
+            TestCase {
+                layout: WidgetLayout::build()
+                    .left(Dimension::exact(10.))
+                    .top(Dimension::exact(20.))
+                    .right(Dimension::exact(30.))
+                    .bottom(Dimension::exact(40.))
+                    .finish(),
+                result: SizedRect::new(Point::new(10., 20.), Size::new(60., 30.)),
+            },
+            TestCase {
+                layout: WidgetLayout::build()
+                    .width(Dimension::exact(40.))
+                    .height(Dimension::exact(30.))
+                    .right(Dimension::exact(30.))
+                    .bottom(Dimension::exact(40.))
+                    .finish(),
+                result: SizedRect::new(Point::new(30., 20.), Size::new(40., 30.)),
+            },
+        ];
+
+        for_each_widget(
+            cases,
+            Size::new(100., 90.),
+            |_| widget_size,
+            |case, result| {
+                if !case.result.approx_eq(&result) {
+                    panic!(
+                        "Layout {:?} produced {:?}, expected {:?}",
+                        case.layout, result, case.result
+                    );
+                }
+            },
         );
     }
 }

--- a/widgets/src/layout/rasterizer.rs
+++ b/widgets/src/layout/rasterizer.rs
@@ -1,6 +1,6 @@
 use gooey_core::{
     figures::{Figure, Point, Rectlike, Size, SizedRect, Vector, Vectorlike},
-    Points, Transmogrifier, TransmogrifierContext,
+    Scaled, Transmogrifier, TransmogrifierContext,
 };
 use gooey_rasterizer::{ContentArea, Rasterizer, Renderer, WidgetRasterizer};
 
@@ -44,8 +44,8 @@ impl<R: Renderer> WidgetRasterizer<R> for LayoutTransmogrifier {
     fn measure_content(
         &self,
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
-        constraints: Size<Option<f32>, Points>,
-    ) -> Size<f32, Points> {
+        constraints: Size<Option<f32>, Scaled>,
+    ) -> Size<f32, Scaled> {
         let mut extents = Vector::default();
         let context_size = context.frontend.renderer().unwrap().size();
         let constrained_size = Size::new(
@@ -60,9 +60,9 @@ impl<R: Renderer> WidgetRasterizer<R> for LayoutTransmogrifier {
 }
 
 #[allow(clippy::cast_precision_loss)]
-fn for_each_measured_widget<R: Renderer, F: FnMut(&LayoutChild, SizedRect<f32, Points>)>(
+fn for_each_measured_widget<R: Renderer, F: FnMut(&LayoutChild, SizedRect<f32, Scaled>)>(
     context: &TransmogrifierContext<'_, LayoutTransmogrifier, Rasterizer<R>>,
-    constraints: Size<f32, Points>,
+    constraints: Size<f32, Scaled>,
     mut callback: F,
 ) {
     for child in context.widget.children.layout_children() {

--- a/widgets/src/layout/rasterizer.rs
+++ b/widgets/src/layout/rasterizer.rs
@@ -26,8 +26,8 @@ impl<R: Renderer> WidgetRasterizer<R> for LayoutTransmogrifier {
         context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
         content_area: &ContentArea,
     ) {
-        let context_size = context.frontend.renderer().unwrap().size();
-        for_each_measured_widget(context, context_size, |layout, child_bounds| {
+        let bounds = content_area.bounds();
+        for_each_measured_widget(context, bounds.size, |layout, child_bounds| {
             context.frontend.with_transmogrifier(
                 layout.registration.id(),
                 |transmogrifier, mut child_context| {

--- a/widgets/src/layout/rasterizer.rs
+++ b/widgets/src/layout/rasterizer.rs
@@ -27,13 +27,15 @@ impl<R: Renderer> WidgetRasterizer<R> for LayoutTransmogrifier {
         content_area: &ContentArea,
     ) {
         let bounds = content_area.bounds();
-        for_each_measured_widget(context, bounds.size, |layout, child_bounds| {
+        for_each_measured_widget(context, bounds.size(), |layout, child_bounds| {
             context.frontend.with_transmogrifier(
                 layout.registration.id(),
                 |transmogrifier, mut child_context| {
                     transmogrifier.render_within(
                         &mut child_context,
-                        child_bounds.translate(content_area.location.to_vector()),
+                        child_bounds
+                            .translate(content_area.location.to_vector())
+                            .as_rect(),
                         context.style,
                     );
                 },

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -21,6 +21,7 @@ pub mod button;
 pub mod checkbox;
 pub mod component;
 pub mod container;
+pub mod input;
 pub mod label;
 pub mod layout;
 pub mod navigator;

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -33,7 +33,7 @@ pub mod rasterized {
 
     use crate::{
         button::ButtonTransmogrifier, checkbox::CheckboxTransmogrifier,
-        container::ContainerTransmogrifier, label::LabelTransmogrifier,
+        container::ContainerTransmogrifier, input::InputTransmogrifier, label::LabelTransmogrifier,
         layout::LayoutTransmogrifier,
     };
 
@@ -45,6 +45,7 @@ pub mod rasterized {
         drop(transmogrifiers.register_transmogrifier(LabelTransmogrifier));
         drop(transmogrifiers.register_transmogrifier(LayoutTransmogrifier));
         drop(transmogrifiers.register_transmogrifier(CheckboxTransmogrifier));
+        drop(transmogrifiers.register_transmogrifier(InputTransmogrifier));
     }
 
     #[must_use]
@@ -59,6 +60,7 @@ pub mod rasterized {
     make_rasterized!(LabelTransmogrifier);
     make_rasterized!(LayoutTransmogrifier);
     make_rasterized!(CheckboxTransmogrifier);
+    make_rasterized!(InputTransmogrifier);
 }
 
 #[cfg(feature = "frontend-browser")]
@@ -68,7 +70,7 @@ pub mod browser {
 
     use crate::{
         button::ButtonTransmogrifier, checkbox::CheckboxTransmogrifier,
-        container::ContainerTransmogrifier, label::LabelTransmogrifier,
+        container::ContainerTransmogrifier, input::InputTransmogrifier, label::LabelTransmogrifier,
         layout::LayoutTransmogrifier,
     };
 
@@ -78,6 +80,7 @@ pub mod browser {
         drop(transmogrifiers.register_transmogrifier(LabelTransmogrifier));
         drop(transmogrifiers.register_transmogrifier(LayoutTransmogrifier));
         drop(transmogrifiers.register_transmogrifier(CheckboxTransmogrifier));
+        drop(transmogrifiers.register_transmogrifier(InputTransmogrifier));
     }
 
     #[must_use]
@@ -92,4 +95,5 @@ pub mod browser {
     make_browser!(LabelTransmogrifier);
     make_browser!(LayoutTransmogrifier);
     make_browser!(CheckboxTransmogrifier);
+    make_browser!(InputTransmogrifier);
 }

--- a/widgets/src/navigator.rs
+++ b/widgets/src/navigator.rs
@@ -165,8 +165,7 @@ impl<Loc: Location> Behavior for NavigatorBehavior<Loc> {
                 WidgetLayout::build()
                     .top(Dimension::zero())
                     .height(Dimension::exact(44.))
-                    .left(Dimension::zero())
-                    .right(Dimension::zero())
+                    .fill_width()
                     .finish(),
             )
             .with_registration(Widgets::Content, initial_widget, content_layout())


### PR DESCRIPTION
Closes #9.

The goal for this pull request is to provide the most basic text field possible: a field that notifies you when its value changes, and allows you to type in it "reasonably" well. Truly making a text edit control that is full featured will take a lot more work.

- [x] Implement cross platform widget
- [x] Implement Browser
- [x] Implement Rasterizer
  - [x] Resurrect `RichText`
  - [x] Reimplement mouse handling
  - [x] Reimplement `character_rect_for_position` and `position_for_location`
  - [x] Implement focus handling
  - [x] Blink cursor properly
  - [x] Add example
  - [x] Implement keyboard events
  - [x] Resurrect clipboard support
  - [x] Split: ~~#28~~
  - [x] Split: ~~#29~~
  - [x] Split: ~~#30~~
- [x] Split: ~~#31~~