### PR TITLE
Initial list implementation

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [alias]
-xtask = "run --package xtask --"
+xtask = "run --package xtask --target-dir xtask/target --"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target/
 Cargo.lock
 *.profraw
 coverage/

--- a/core/src/gooey.rs
+++ b/core/src/gooey.rs
@@ -458,8 +458,8 @@ impl<K: Key> KeyedStorage<K> for WidgetStorage {
 pub trait RelatedStorage<K: Key>: Debug + Send + Sync + 'static {
     /// Returns the registration of the widget that this is from.
     fn widget(&self) -> WeakWidgetRegistration;
-    /// Removes the widget with `key` from this storage.
-    fn remove(&self, key: &K);
+    /// Removes the widget with `key` from this storage. Returns the removed registration if one was removed.
+    fn remove(&self, key: &K) -> Option<WeakWidgetRegistration>;
     /// Registers `widget` with `key`.
     fn register(&self, key: K, widget: &WidgetRegistration);
 }

--- a/core/src/styles/padding.rs
+++ b/core/src/styles/padding.rs
@@ -15,15 +15,6 @@ impl StyleComponent for Padding {
     fn should_be_inherited(&self) -> bool {
         false
     }
-
-    fn merge(&self, other: &Self) -> Self {
-        Self(Surround {
-            left: self.left.or(other.left),
-            top: self.top.or(other.top),
-            right: self.right.or(other.right),
-            bottom: self.bottom.or(other.bottom),
-        })
-    }
 }
 
 impl Padding {

--- a/frontends/browser/src/lib.rs
+++ b/frontends/browser/src/lib.rs
@@ -434,6 +434,8 @@ pub trait WebSysTransmogrifier: Transmogrifier<WebSys> {
 
         if let Some(padding) = style.get::<Padding>() {
             css = css.with_padding(padding);
+        } else {
+            css = css.with_css_statement("padding: 0");
         }
 
         css

--- a/frontends/browser/src/utils.rs
+++ b/frontends/browser/src/utils.rs
@@ -273,14 +273,14 @@ impl CssBlockBuilder {
                     self.with_css_statement(&format!(
                         "padding: {:03}pt {:03}pt",
                         top.get(),
-                        left.get()
+                        right.get()
                     ))
                 }
             } else {
                 self.with_css_statement(&format!(
                     "padding: {:03}pt {:03}pt {:03}pt",
                     top.get(),
-                    left.get(),
+                    right.get(),
                     bottom.get(),
                 ))
             }
@@ -288,9 +288,9 @@ impl CssBlockBuilder {
             self.with_css_statement(&format!(
                 "padding: {:03}pt {:03}pt {:03}pt {:03}pt",
                 top.get(),
-                left.get(),
-                bottom.get(),
                 right.get(),
+                bottom.get(),
+                left.get(),
             ))
         }
     }

--- a/gooey/examples/lists.rs
+++ b/gooey/examples/lists.rs
@@ -1,0 +1,93 @@
+//! This is a simple demonstration of the List widget.
+//!
+//! The list widget is *not* a table view. It is the equivalent of
+//! unordered/ordered lists in html.
+//!
+//! This example is more of a testbed and not a good example -- it will be
+//! replaced with something better eventually.
+
+use gooey::{
+    core::{Context, DefaultWidget, StyledWidget},
+    widgets::component::{Behavior, Component, Content, EventMapper},
+    App,
+};
+use gooey_core::Callback;
+use gooey_widgets::{
+    button::Button,
+    label::Label,
+    list::{List, OrderedListKind},
+};
+
+#[cfg(test)]
+mod harness;
+
+fn app() -> App {
+    App::from_root(|storage| Component::<Lists>::default_for(storage)).with_component::<Lists>()
+}
+
+fn main() {
+    app().run();
+}
+
+#[derive(Clone, Default, Debug)]
+struct Lists {
+    count: u32,
+}
+
+impl Behavior for Lists {
+    type Content = List;
+    type Event = ();
+    type Widgets = ();
+
+    fn build_content(
+        &mut self,
+        builder: <Self::Content as Content<Self>>::Builder,
+        _events: &EventMapper<Self>,
+    ) -> StyledWidget<List> {
+        let sub_list = List::unadorned(builder.storage())
+            .with(Label::new("Sub List"))
+            .with(
+                List::build(builder.storage())
+                    .ordered(OrderedListKind::RomanLower)
+                    .with(Label::new("Sub 1"))
+                    .with(Label::new("Sub 2"))
+                    .with(Label::new("Test"))
+                    .with(Label::new("Test"))
+                    .with(Label::new("Test"))
+                    .with(Label::new("Test"))
+                    .with(Label::new("Test"))
+                    .with(Label::new("Test"))
+                    .with(Label::new("Test"))
+                    .with(Label::new("Test"))
+                    .with(Label::new("Test"))
+                    .with(Label::new("Test"))
+                    .with(Label::new("Test"))
+                    .finish(),
+            )
+            .finish();
+        builder
+            .ordered(OrderedListKind::RomanUpper)
+            .with(Label::new("Test"))
+            .with(sub_list)
+            .with(Label::new("Test"))
+            .with(Label::new("Test"))
+            .with(Label::new("Test"))
+            .with(Label::new("Test"))
+            .with(Label::new("Test"))
+            .with(Label::new("Test"))
+            .with(Label::new("Test"))
+            .with(Label::new("Test"))
+            .with(Label::new("Test"))
+            .with(Label::new("Test"))
+            .with(Label::new("Test"))
+            .with(Button::new("Test", Callback::default()))
+            .finish()
+    }
+
+    fn receive_event(
+        _component: &mut Component<Self>,
+        _event: Self::Event,
+        _context: &Context<Component<Self>>,
+    ) {
+    }
+}

--- a/gooey/src/style.rs
+++ b/gooey/src/style.rs
@@ -12,6 +12,7 @@ use gooey_widgets::{
     checkbox::Checkbox,
     input::Input,
     label::Label,
+    list::{List, ListAdornmentSpacing},
 };
 
 /// The default [`StyleSheet`] for `Gooey`.
@@ -25,7 +26,11 @@ pub fn default_stylesheet() -> StyleSheet {
 #[allow(clippy::too_many_lines)]
 pub fn stylesheet_for_palette<P: Palette>() -> StyleSheet {
     StyleSheet::default()
-        .with(Rule::default().with_styles(|style| style.with(HighlightColor(P::secondary()))))
+        .with(Rule::default().with_styles(|style| {
+            style
+                .with(HighlightColor(P::secondary()))
+                .with(ForegroundColor(P::foreground()))
+        }))
         .with(
             Rule::for_classes(ROOT_CLASS)
                 .with_styles(|style| style.with(BackgroundColor(P::background()))),
@@ -49,11 +54,10 @@ pub fn stylesheet_for_palette<P: Palette>() -> StyleSheet {
                 .when_active()
                 .with_styles(|style| style.with(ButtonColor(P::navigator_button().darken(0.1)))),
         )
-        .with(Rule::for_classes(SOLID_WIDGET_CLASS).with_styles(|style| {
-            style
-                .with(ForegroundColor(P::foreground()))
-                .with(BackgroundColor(P::control_background()))
-        }))
+        .with(
+            Rule::for_classes(SOLID_WIDGET_CLASS)
+                .with_styles(|style| style.with(BackgroundColor(P::control_background()))),
+        )
         .with(
             Rule::for_classes(SOLID_WIDGET_CLASS)
                 .when_hovered()
@@ -86,11 +90,10 @@ pub fn stylesheet_for_palette<P: Palette>() -> StyleSheet {
                 .with(VerticalAlignment::Center)
                 .with(Padding(Surround::from(Some(Figure::new(5.)))))
         }))
-        .with(Rule::for_widget::<Checkbox>().with_styles(|style| {
-            style
-                .with(ForegroundColor(P::foreground()))
-                .with(ButtonColor(P::control_background()))
-        }))
+        .with(
+            Rule::for_widget::<Checkbox>()
+                .with_styles(|style| style.with(ButtonColor(P::control_background()))),
+        )
         .with(
             Rule::for_widget::<Checkbox>()
                 .when_hovered()
@@ -117,7 +120,6 @@ pub fn stylesheet_for_palette<P: Palette>() -> StyleSheet {
         .with(Rule::for_widget::<Input>().with_styles(|style| {
             style
                 .with(BackgroundColor(P::background()))
-                .with(ForegroundColor(P::foreground()))
                 .with(Border::uniform(BorderOptions::new(
                     1.,
                     P::control_background(),
@@ -130,6 +132,10 @@ pub fn stylesheet_for_palette<P: Palette>() -> StyleSheet {
                 .with_styles(|style| {
                     style.with(Border::uniform(BorderOptions::new(1., P::secondary())))
                 }),
+        )
+        .with(
+            Rule::for_widget::<List>()
+                .with_styles(|style| style.with(ListAdornmentSpacing(Figure::new(5.)))),
         )
 }
 

--- a/widgets/Cargo.toml
+++ b/widgets/Cargo.toml
@@ -23,6 +23,7 @@ gooey-rasterizer = { path = "../frontends/rasterizer", version = "0.1.0-dev.0", 
 gooey-browser = { path = "../frontends/browser", version = "0.1.0-dev.0", optional = true }
 
 arboard = { version = "2", optional = true }
+septem = "1.1"
 
 wasm-bindgen = { version = "0.2", optional = true }
 web-sys = { version = "0.3", features = [
@@ -40,6 +41,7 @@ web-sys = { version = "0.3", features = [
     "HtmlHeadElement",
     "HtmlLabelElement",
     "HtmlSpanElement",
+    "HtmlTableElement",
     "CssStyleDeclaration",
 ], optional = true }
 flume = "0.10"

--- a/widgets/src/component.rs
+++ b/widgets/src/component.rs
@@ -259,9 +259,9 @@ impl<B: Behavior> RelatedStorage<B::Widgets> for ComponentUpdater<B> {
         self.component.clone()
     }
 
-    fn remove(&self, key: &B::Widgets) {
+    fn remove(&self, key: &B::Widgets) -> Option<WeakWidgetRegistration> {
         let mut registered_widgets = self.registered_widgets.lock();
-        registered_widgets.remove(key);
+        registered_widgets.remove(key)
     }
 
     fn register(&self, key: B::Widgets, registration: &WidgetRegistration) {

--- a/widgets/src/component/rasterizer.rs
+++ b/widgets/src/component/rasterizer.rs
@@ -38,7 +38,7 @@ impl<R: Renderer, B: Behavior> WidgetRasterizer<R> for ComponentTransmogrifier<B
                         .total_size()
                 },
             )
-            .unwrap_or_default()
+            .unwrap()
     }
 }
 

--- a/widgets/src/layout.rs
+++ b/widgets/src/layout.rs
@@ -125,7 +125,6 @@ pub struct Builder<K: Key, S: KeyedStorage<K>> {
 struct ChildrenMap<K> {
     children: HashMap<u32, LayoutChild>,
     keys_to_id: HashMap<K, u32>,
-    order: Vec<u32>,
 }
 
 impl<K> Default for ChildrenMap<K> {
@@ -133,38 +132,24 @@ impl<K> Default for ChildrenMap<K> {
         Self {
             children: HashMap::default(),
             keys_to_id: HashMap::default(),
-            order: Vec::default(),
         }
     }
 }
 
 impl<K: Key> ChildrenMap<K> {
     fn remove(&mut self, key: &K) -> Option<LayoutChild> {
-        self.keys_to_id.remove(key).and_then(|id| {
-            match self.order.binary_search(&id) {
-                Ok(index) => {
-                    self.order.remove(index);
-                }
-                Err(_) => unreachable!(),
-            }
-            self.children.remove(&id)
-        })
+        self.keys_to_id
+            .remove(key)
+            .and_then(|id| self.children.remove(&id))
     }
 
     fn insert(&mut self, key: Option<K>, child: LayoutChild) -> Option<LayoutChild> {
         let mut old_child = None;
         if let Some(key) = key {
             if let Some(removed_widget) = self.keys_to_id.insert(key, child.registration.id().id) {
-                match self.order.binary_search(&removed_widget) {
-                    Ok(index) => {
-                        self.order.remove(index);
-                    }
-                    Err(_) => unreachable!(),
-                }
                 old_child = self.children.remove(&removed_widget);
             }
         }
-        self.order.push(child.registration.id().id);
         self.children.insert(child.registration.id().id, child);
         old_child
     }
@@ -387,11 +372,7 @@ pub struct LayoutTransmogrifier;
 
 impl<K: Key> LayoutChildren for ChildrenMap<K> {
     fn layout_children(&self) -> Vec<LayoutChild> {
-        self.order
-            .iter()
-            .map(|id| self.children.get(id).unwrap())
-            .cloned()
-            .collect()
+        self.children.values().cloned().collect()
     }
 
     fn child_by_widget_id(&self, widget_id: &WidgetId) -> Option<&LayoutChild> {

--- a/widgets/src/layout/browser.rs
+++ b/widgets/src/layout/browser.rs
@@ -8,9 +8,9 @@ use gooey_core::{Transmogrifier, TransmogrifierContext};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlDivElement, HtmlElement};
 
+use super::LayoutChildren;
 use crate::layout::{
-    Dimension, Layout, LayoutChild, LayoutChildren, LayoutCommand, LayoutTransmogrifier,
-    WidgetLayout,
+    Dimension, Layout, LayoutChild, LayoutCommand, LayoutTransmogrifier, WidgetLayout,
 };
 
 #[derive(Default, Debug)]

--- a/widgets/src/lib.rs
+++ b/widgets/src/lib.rs
@@ -24,6 +24,7 @@ pub mod container;
 pub mod input;
 pub mod label;
 pub mod layout;
+pub mod list;
 pub mod navigator;
 
 #[cfg(feature = "frontend-rasterizer")]
@@ -34,7 +35,7 @@ pub mod rasterized {
     use crate::{
         button::ButtonTransmogrifier, checkbox::CheckboxTransmogrifier,
         container::ContainerTransmogrifier, input::InputTransmogrifier, label::LabelTransmogrifier,
-        layout::LayoutTransmogrifier,
+        layout::LayoutTransmogrifier, list::ListTransmogrifier,
     };
 
     pub fn register_transmogrifiers<R: Renderer>(
@@ -46,6 +47,7 @@ pub mod rasterized {
         drop(transmogrifiers.register_transmogrifier(LayoutTransmogrifier));
         drop(transmogrifiers.register_transmogrifier(CheckboxTransmogrifier));
         drop(transmogrifiers.register_transmogrifier(InputTransmogrifier));
+        drop(transmogrifiers.register_transmogrifier(ListTransmogrifier));
     }
 
     #[must_use]
@@ -61,6 +63,7 @@ pub mod rasterized {
     make_rasterized!(LayoutTransmogrifier);
     make_rasterized!(CheckboxTransmogrifier);
     make_rasterized!(InputTransmogrifier);
+    make_rasterized!(ListTransmogrifier);
 }
 
 #[cfg(feature = "frontend-browser")]
@@ -71,7 +74,7 @@ pub mod browser {
     use crate::{
         button::ButtonTransmogrifier, checkbox::CheckboxTransmogrifier,
         container::ContainerTransmogrifier, input::InputTransmogrifier, label::LabelTransmogrifier,
-        layout::LayoutTransmogrifier,
+        layout::LayoutTransmogrifier, list::ListTransmogrifier,
     };
 
     pub fn register_transmogrifiers(transmogrifiers: &mut Transmogrifiers<WebSys>) {
@@ -81,6 +84,7 @@ pub mod browser {
         drop(transmogrifiers.register_transmogrifier(LayoutTransmogrifier));
         drop(transmogrifiers.register_transmogrifier(CheckboxTransmogrifier));
         drop(transmogrifiers.register_transmogrifier(InputTransmogrifier));
+        drop(transmogrifiers.register_transmogrifier(ListTransmogrifier));
     }
 
     #[must_use]
@@ -96,4 +100,5 @@ pub mod browser {
     make_browser!(LayoutTransmogrifier);
     make_browser!(CheckboxTransmogrifier);
     make_browser!(InputTransmogrifier);
+    make_browser!(ListTransmogrifier);
 }

--- a/widgets/src/list.rs
+++ b/widgets/src/list.rs
@@ -1,0 +1,334 @@
+use std::{borrow::Cow, fmt::Debug, marker::PhantomData};
+
+use gooey_core::{
+    figures::Figure,
+    styles::{Padding, StyleComponent},
+    Context, Key, KeyedStorage, RelatedStorage, Scaled, StyledWidget, Widget, WidgetId,
+    WidgetRegistration, WidgetStorage,
+};
+use septem::Roman;
+
+use crate::component::{Behavior, ComponentBuilder, Content, ContentBuilder};
+
+#[cfg(feature = "gooey-rasterizer")]
+mod rasterizer;
+
+#[cfg(feature = "frontend-browser")]
+mod browser;
+
+#[derive(Debug)]
+pub enum Kind {
+    Unordered {
+        kind: UnorderedListKind,
+    },
+    Ordered {
+        start: Option<i32>,
+        kind: OrderedListKind,
+        reversed: bool,
+    },
+}
+
+impl Kind {
+    #[must_use]
+    pub const fn is_unordered(&self) -> bool {
+        matches!(self, Kind::Unordered { .. })
+    }
+
+    #[must_use]
+    pub const fn is_ordered(&self) -> bool {
+        !self.is_unordered()
+    }
+
+    #[must_use]
+    pub const fn is_unadorned(&self) -> bool {
+        matches!(
+            self,
+            Self::Unordered {
+                kind: UnorderedListKind::None
+            }
+        )
+    }
+}
+
+impl Default for Kind {
+    fn default() -> Self {
+        Self::Unordered {
+            kind: UnorderedListKind::Bullet,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum OrderedListKind {
+    Decimal,
+    AlphaLower,
+    AlphaUpper,
+    RomanLower,
+    RomanUpper,
+}
+
+impl Default for OrderedListKind {
+    fn default() -> Self {
+        Self::Decimal
+    }
+}
+
+#[derive(Debug)]
+pub enum UnorderedListKind {
+    None,
+    Bullet,
+    Circle,
+    Square,
+}
+
+#[derive(Debug)]
+pub struct List {
+    children: Vec<WidgetRegistration>,
+    kind: Kind,
+}
+
+impl List {
+    #[must_use]
+    pub fn build(storage: &WidgetStorage) -> Builder<(), WidgetStorage> {
+        Builder::new(storage.clone())
+    }
+
+    #[must_use]
+    pub fn bulleted(storage: &WidgetStorage) -> Builder<(), WidgetStorage> {
+        Builder::new(storage.clone()).bulleted()
+    }
+
+    #[must_use]
+    pub fn unadorned(storage: &WidgetStorage) -> Builder<(), WidgetStorage> {
+        Builder::new(storage.clone()).unadorned()
+    }
+
+    pub fn remove(&mut self, index: usize, context: &Context<Self>) -> WidgetRegistration {
+        let removed_child = self.children.remove(index);
+        context.send_command(ListCommand::ChildRemoved(removed_child.id().clone()));
+        removed_child
+    }
+
+    pub fn push<W: Widget>(&mut self, widget: StyledWidget<W>, context: &Context<Self>) {
+        let registration = context.register(widget);
+        self.push_registration(registration, context);
+    }
+
+    pub fn push_registration(&mut self, registration: WidgetRegistration, context: &Context<Self>) {
+        self.children.push(registration.clone());
+
+        context.send_command(ListCommand::ChildAdded(registration));
+    }
+}
+
+#[derive(Debug)]
+pub enum ListCommand {
+    ChildRemoved(WidgetId),
+    ChildAdded(WidgetRegistration),
+}
+
+impl Widget for List {
+    type Command = ListCommand;
+    type Event = ();
+
+    const CLASS: &'static str = "gooey-list";
+    const FOCUSABLE: bool = false;
+}
+
+#[derive(Debug)]
+pub struct Builder<K: Key, S: KeyedStorage<K>> {
+    storage: S,
+    kind: Kind,
+    children: Vec<WidgetRegistration>,
+    _phantom: PhantomData<K>,
+}
+
+impl<K: Key, S: KeyedStorage<K>> Builder<K, S> {
+    pub fn storage(&self) -> &WidgetStorage {
+        self.storage.storage()
+    }
+
+    pub fn bulleted(mut self) -> Self {
+        self.kind = Kind::Unordered {
+            kind: UnorderedListKind::Bullet,
+        };
+        self
+    }
+
+    pub fn unadorned(mut self) -> Self {
+        self.kind = Kind::Unordered {
+            kind: UnorderedListKind::None,
+        };
+        self
+    }
+
+    pub fn ordered(mut self, kind: OrderedListKind) -> Self {
+        self.kind = Kind::Ordered {
+            start: None,
+            kind,
+            reversed: false,
+        };
+        self
+    }
+
+    pub fn reversed(mut self) -> Self {
+        match &mut self.kind {
+            Kind::Ordered { reversed, .. } => *reversed = true,
+            Kind::Unordered { .. } => panic!("Call reversed() only after calling ordered()"),
+        }
+        self
+    }
+
+    pub fn start_at(mut self, start_at: i32) -> Self {
+        match &mut self.kind {
+            Kind::Ordered { start, .. } => *start = Some(start_at),
+            Kind::Unordered { .. } => panic!("Call start_at() only after calling ordered()"),
+        }
+        self
+    }
+
+    pub fn with<W: Widget>(mut self, widget: StyledWidget<W>) -> Self {
+        let widget = self.storage.register(None, widget);
+        self.with_registration(widget)
+    }
+
+    pub fn with_registration(mut self, registration: WidgetRegistration) -> Self {
+        self.children.push(registration);
+        self
+    }
+
+    pub fn finish(self) -> StyledWidget<List> {
+        let is_unadorned = self.kind.is_unadorned();
+        let widget = StyledWidget::from(List {
+            children: self.children,
+            kind: self.kind,
+        });
+        if is_unadorned {
+            widget.with(Padding::default())
+        } else {
+            widget
+        }
+    }
+}
+
+impl<B: Behavior> Content<B> for List {
+    type Builder = Builder<B::Widgets, ComponentBuilder<B>>;
+
+    fn build(storage: ComponentBuilder<B>) -> Self::Builder {
+        Builder::new(storage)
+    }
+}
+
+impl<'a, K: Key, S: KeyedStorage<K>> ContentBuilder<K, S> for Builder<K, S> {
+    fn new(storage: S) -> Self {
+        Self {
+            storage,
+            kind: Kind::default(),
+            children: Vec::default(),
+            _phantom: PhantomData,
+        }
+    }
+
+    fn storage(&self) -> &WidgetStorage {
+        self.storage.storage()
+    }
+
+    fn related_storage(&self) -> Option<Box<dyn RelatedStorage<K>>> {
+        self.storage.related_storage()
+    }
+}
+
+#[derive(Debug)]
+pub struct ListTransmogrifier;
+
+#[derive(Default, Debug, Clone)]
+pub struct ListAdornmentSpacing(pub Figure<f32, Scaled>);
+
+impl StyleComponent for ListAdornmentSpacing {}
+
+#[allow(clippy::map_entry)]
+#[must_use]
+pub fn item_label(value: Option<i32>, kind: &Kind) -> Option<Cow<'static, str>> {
+    match kind {
+        Kind::Unordered { kind } => match kind {
+            UnorderedListKind::None => None,
+            UnorderedListKind::Bullet => {
+                // bullet point
+                Some(Cow::Borrowed("\u{2022}"))
+            }
+            UnorderedListKind::Circle => Some(Cow::Borrowed("\u{25E6}")),
+            UnorderedListKind::Square => Some(Cow::Borrowed("\u{25AA}")),
+        },
+        Kind::Ordered { kind, .. } => {
+            let value = value.expect("value is required for ordered indicators");
+            match kind {
+                OrderedListKind::Decimal => Some(Cow::Owned(format!("{}.", value))),
+                OrderedListKind::AlphaLower => Some(Cow::Owned(alpha(value, 'a'))),
+                OrderedListKind::AlphaUpper => Some(Cow::Owned(alpha(value, 'A'))),
+                OrderedListKind::RomanLower | OrderedListKind::RomanUpper => {
+                    let sign = if value.is_negative() { "-" } else { "" };
+                    let as_positive = value.abs() as u32;
+                    let roman = Roman::from(as_positive).unwrap();
+                    Some(Cow::Owned(if matches!(kind, OrderedListKind::RomanUpper) {
+                        format!("{}{}.", sign, roman.to_uppercase())
+                    } else {
+                        format!("{}{}.", sign, roman.to_lowercase())
+                    }))
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn alpha(mut value: i32, a: char) -> String {
+    let mut output = String::new();
+    while value > 0 {
+        let ch = (a as u8 + (value % 26) as u8) as char;
+        output.push(ch);
+        value /= 26;
+    }
+    output.push('.');
+    output
+}
+
+#[must_use]
+pub struct ItemLabelIterator<'a> {
+    pub kind: &'a Kind,
+    pub value: Option<i32>,
+    increment: i32,
+    remaining: usize,
+}
+
+impl<'a> ItemLabelIterator<'a> {
+    pub fn new(kind: &'a Kind, count: usize) -> Self {
+        let (value, increment) = match kind {
+            Kind::Unordered { .. } => (None, 0),
+            Kind::Ordered {
+                start, reversed, ..
+            } => (Some(start.unwrap_or(1)), if *reversed { -1 } else { 1 }),
+        };
+
+        Self {
+            kind,
+            value,
+            increment,
+            remaining: count,
+        }
+    }
+}
+
+impl<'a> Iterator for ItemLabelIterator<'a> {
+    type Item = Option<Cow<'static, str>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            None
+        } else {
+            self.remaining -= 1;
+            let indicator = item_label(self.value, self.kind);
+            self.value = self.value.map(|value| value.wrapping_add(self.increment));
+            Some(indicator)
+        }
+    }
+}

--- a/widgets/src/list/browser.rs
+++ b/widgets/src/list/browser.rs
@@ -1,0 +1,138 @@
+//! Browser implementation of the List widget.
+//!
+//! Despite this widget being inspired by the <ol> and <ul> tags, the browser
+//! implements lists adornments by utilizing the padding area, but causes many
+//! issues. By switching to a table, we can achieve much more flexible and
+//! consistent layout options.
+
+use gooey_browser::{
+    utils::{create_element, window_element_by_widget_id, CssBlockBuilder, CssRules},
+    WebSys, WebSysTransmogrifier,
+};
+use gooey_core::{
+    styles::style_sheet::State, Frontend, Transmogrifier, TransmogrifierContext, WidgetRegistration,
+};
+use wasm_bindgen::JsCast;
+use web_sys::{HtmlDivElement, HtmlElement, HtmlTableElement};
+
+use super::ItemLabelIterator;
+use crate::list::{List, ListAdornmentSpacing, ListCommand, ListTransmogrifier};
+
+impl Transmogrifier<WebSys> for ListTransmogrifier {
+    type State = Option<CssRules>;
+    type Widget = List;
+
+    fn receive_command(
+        &self,
+        command: ListCommand,
+        context: &mut TransmogrifierContext<'_, Self, WebSys>,
+    ) {
+        match command {
+            ListCommand::ChildRemoved(child) => {
+                // We need to remove the <tr>, not just the child.
+                if let Some(tr) = window_element_by_widget_id::<HtmlElement>(child.id)
+                    .and_then(|child| child.parent_node())
+                    .and_then(|td| td.parent_node())
+                {
+                    let td = tr.parent_node().unwrap();
+                    td.remove_child(&td).unwrap();
+                }
+            }
+            ListCommand::ChildAdded(_child) => {
+                if let Some(_table) =
+                    window_element_by_widget_id::<HtmlDivElement>(context.registration.id().id)
+                {
+                    todo!(
+                        "need to insert the value at the correct location, and then update the \
+                         remaining indicators"
+                    )
+                    // materialize_child(&child, context, &container);
+                }
+            }
+        }
+    }
+}
+
+impl WebSysTransmogrifier for ListTransmogrifier {
+    fn transmogrify(
+        &self,
+        context: TransmogrifierContext<'_, Self, WebSys>,
+    ) -> Option<web_sys::HtmlElement> {
+        let container = create_element::<HtmlTableElement>("table");
+        container.set_attribute("aria-role", "list").unwrap();
+        let effective_style = context
+            .frontend
+            .gooey()
+            .stylesheet()
+            .effective_style_for::<Self::Widget>(context.style.clone(), &State::default());
+        let spacing = effective_style.get_or_default::<ListAdornmentSpacing>();
+        let css = self
+            .initialize_widget_element(&container, &context)
+            .unwrap_or_default()
+            .and(
+                &CssBlockBuilder::for_id(context.registration.id().id)
+                    .and_additional_selector(" td")
+                    .with_css_statement("vertical-align: baseline")
+                    .to_string(),
+            )
+            .and(
+                &CssBlockBuilder::for_id(context.registration.id().id)
+                    .and_additional_selector(" td.label")
+                    .with_css_statement("text-align: right")
+                    .with_css_statement(&format!("padding-right: {:.03}pt", spacing.0.get()))
+                    .to_string(),
+            );
+        *context.state = Some(css);
+
+        let mut labels =
+            ItemLabelIterator::new(&context.widget.kind, context.widget.children.len());
+        for child in context.widget.children.clone() {
+            materialize_child(
+                labels.next().unwrap().as_deref(),
+                &child,
+                &context,
+                &container,
+            );
+        }
+        Some(container.unchecked_into())
+    }
+}
+
+fn materialize_child(
+    item_label: Option<&str>,
+    layout_child: &WidgetRegistration,
+    context: &TransmogrifierContext<'_, ListTransmogrifier, WebSys>,
+    container: &HtmlElement,
+) {
+    context.frontend.with_transmogrifier(
+        layout_child.id(),
+        |child_transmogrifier, mut child_context| {
+            if let Some(child) = child_transmogrifier.transmogrify(&mut child_context) {
+                let tr = create_element::<HtmlElement>("tr");
+                tr.set_attribute("aria-role", "listitem").unwrap();
+
+                if let Some(item_label) = item_label {
+                    let indicator = create_element::<HtmlElement>("td");
+                    indicator
+                        .set_attribute("aria-role", "presentation")
+                        .unwrap();
+                    indicator.class_list().add_1("label").unwrap();
+                    indicator.set_inner_text(item_label);
+                    tr.append_child(&indicator)
+                        .expect("error appending indicator");
+                }
+
+                let child_cell = create_element::<HtmlElement>("td");
+                child_cell
+                    .set_attribute("aria-role", "presentation")
+                    .unwrap();
+                child_cell
+                    .append_child(&child)
+                    .expect("error appending child");
+                container.append_child(&tr).expect("error appending tr");
+                tr.append_child(&child_cell)
+                    .expect("error appending content");
+            }
+        },
+    );
+}

--- a/widgets/src/list/rasterizer.rs
+++ b/widgets/src/list/rasterizer.rs
@@ -1,0 +1,236 @@
+use std::collections::HashMap;
+
+use gooey_core::{
+    figures::{Figure, Point, Rectlike, Size, SizedRect, Vector, Zero},
+    styles::{Style, TextColor},
+    Scaled, Transmogrifier, TransmogrifierContext, WidgetRegistration,
+};
+use gooey_rasterizer::{ContentArea, Rasterizer, Renderer, WidgetRasterizer};
+use gooey_text::{prepared::PreparedText, wrap::TextWrap, Text};
+
+use super::{ItemLabelIterator, Kind, ListAdornmentSpacing};
+use crate::list::{List, ListTransmogrifier};
+
+impl<R: Renderer> Transmogrifier<Rasterizer<R>> for ListTransmogrifier {
+    type State = State;
+    type Widget = List;
+
+    fn receive_command(
+        &self,
+        _command: <Self::Widget as gooey_core::Widget>::Command,
+        context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
+    ) {
+        context.frontend.set_needs_redraw();
+    }
+}
+
+impl<R: Renderer> WidgetRasterizer<R> for ListTransmogrifier {
+    fn render(
+        &self,
+        context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
+        content_area: &ContentArea,
+    ) {
+        let renderer = context.frontend.renderer().unwrap();
+        let bounds = content_area.bounds();
+        let indicators = context
+            .state
+            .indicators(
+                &context.widget.kind,
+                context.widget.children.len(),
+                renderer,
+                context.style,
+            )
+            .collect::<Vec<_>>();
+        let max_indicator_width = indicators
+            .iter()
+            .filter_map(|text| text.as_ref().map(|t| t.size().width()))
+            .reduce(Figure::max);
+        let spacing = context.style.get_or_default::<ListAdornmentSpacing>().0;
+        let offset_amount = max_indicator_width
+            .map_or_else(Figure::default, |max_indicator_width| {
+                max_indicator_width + spacing
+            });
+
+        let mut indicators = indicators.into_iter();
+        for_each_measured_widget(
+            context,
+            bounds.size() - Vector::from_figures(offset_amount, Figure::default()),
+            |child, mut child_bounds| {
+                child_bounds = child_bounds.translate(
+                    content_area.location + Vector::from_figures(offset_amount, Figure::default()),
+                );
+
+                if let Some(indicator) = indicators.next().unwrap() {
+                    indicator.render::<TextColor, _>(
+                        renderer,
+                        child_bounds.origin
+                            - Vector::from_figures(
+                                spacing + indicator.size().width(),
+                                Figure::default(),
+                            ),
+                        true,
+                        Some(context.style),
+                    );
+                }
+
+                context.frontend.with_transmogrifier(
+                    child.id(),
+                    |transmogrifier, mut child_context| {
+                        transmogrifier.render_within(
+                            &mut child_context,
+                            child_bounds.as_rect(),
+                            Some(context.registration.id()),
+                            context.style,
+                        );
+                    },
+                );
+            },
+        );
+    }
+
+    fn measure_content(
+        &self,
+        context: &mut TransmogrifierContext<'_, Self, Rasterizer<R>>,
+        constraints: Size<Option<f32>, Scaled>,
+    ) -> Size<f32, Scaled> {
+        let mut size = Size::<f32, Scaled>::default();
+        let renderer = context.frontend.renderer().unwrap();
+        let context_size = renderer.size();
+        let spacing = context.style.get_or_default::<ListAdornmentSpacing>().0;
+        context.state.clear_indicator_state();
+        let max_indicator_width = context
+            .state
+            .indicators(
+                &context.widget.kind,
+                context.widget.children.len(),
+                renderer,
+                context.style,
+            )
+            .filter_map(|text| text.as_ref().map(|t| t.size().width()))
+            .reduce(Figure::max);
+        let offset_amount = max_indicator_width
+            .map(|width| spacing + width)
+            .unwrap_or_default();
+
+        let constrained_size = Size::new(
+            constraints.width.unwrap_or(context_size.width) - offset_amount.get(),
+            constraints.height.unwrap_or(context_size.height),
+        );
+        for_each_measured_widget(context, constrained_size, |_layout, child_bounds| {
+            size.width = size.width.max(child_bounds.size.width);
+            size.height += child_bounds.size.height;
+        });
+        size.width += offset_amount.get();
+        size
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn for_each_measured_widget<R: Renderer, F: FnMut(&WidgetRegistration, SizedRect<f32, Scaled>)>(
+    context: &TransmogrifierContext<'_, ListTransmogrifier, Rasterizer<R>>,
+    constraints: Size<f32, Scaled>,
+    callback: F,
+) {
+    for_each_widget(
+        &context.widget.children,
+        |child| {
+            context
+                .frontend
+                .with_transmogrifier(child.id(), |transmogrifier, mut child_context| {
+                    let child_size = transmogrifier
+                        .content_size(&mut child_context, Size::new(Some(constraints.width), None))
+                        .total_size();
+                    Size::new(constraints.width, child_size.height)
+                })
+                .expect("unknown transmogrifier")
+        },
+        callback,
+    );
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn for_each_widget<
+    F: FnMut(&WidgetRegistration, SizedRect<f32, Scaled>),
+    W: Fn(&WidgetRegistration) -> Size<f32, Scaled>,
+>(
+    children: &[WidgetRegistration],
+    child_measurer: W,
+    mut callback: F,
+) {
+    let mut top = Figure::default();
+    for child in children {
+        let child_size = child_measurer(child).max(&Size::default());
+        callback(
+            child,
+            SizedRect::new(Point::from_figures(Figure::zero(), top), child_size),
+        );
+        top += child_size.height();
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct State {
+    indicators: HashMap<Option<i32>, PreparedText>,
+}
+
+impl State {
+    fn clear_indicator_state(&mut self) {
+        self.indicators.clear();
+    }
+
+    #[allow(clippy::map_entry)]
+    fn indicator(
+        &mut self,
+        value: Option<i32>,
+        label: &str,
+        renderer: &impl Renderer,
+        context_style: &Style,
+    ) -> Option<PreparedText> {
+        if !self.indicators.contains_key(&value) {
+            let text = Text::from(label);
+            self.indicators.insert(
+                value,
+                text.wrap(renderer, TextWrap::NoWrap, Some(context_style)),
+            );
+        }
+
+        self.indicators.get(&value).cloned()
+    }
+
+    fn indicators<'a, R: Renderer>(
+        &'a mut self,
+        kind: &'a Kind,
+        count: usize,
+        renderer: &'a R,
+        context_style: &'a Style,
+    ) -> PreparedLabelIterator<'a, R> {
+        PreparedLabelIterator {
+            state: self,
+            labels: ItemLabelIterator::new(kind, count),
+            renderer,
+            context_style,
+        }
+    }
+}
+
+struct PreparedLabelIterator<'a, R: Renderer> {
+    labels: ItemLabelIterator<'a>,
+    state: &'a mut State,
+    renderer: &'a R,
+    context_style: &'a Style,
+}
+
+impl<'a, R: Renderer> Iterator for PreparedLabelIterator<'a, R> {
+    type Item = Option<PreparedText>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.labels.next()?.map(|label| {
+            self.state.indicator(
+                self.labels.value,
+                label.as_ref(),
+                self.renderer,
+                self.context_style,
+            )
+        })
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -38,9 +38,11 @@ fn build_browser_example(name: String) -> Result<(), devx_cmd::Error> {
                 "bonsaidb-counter-client",
                 "--target",
                 "wasm32-unknown-unknown",
+                "--target-dir",
+                "target/wasm",
             )?;
             execute_wasm_bindgen(
-                "target/wasm32-unknown-unknown/debug/bonsaidb-counter-client.wasm",
+                "target/wasm/wasm32-unknown-unknown/debug/bonsaidb-counter-client.wasm",
                 "integrated-examples/bonsaidb/counter/browser/pkg/",
             )?;
 
@@ -53,7 +55,7 @@ fn build_browser_example(name: String) -> Result<(), devx_cmd::Error> {
             build_regular_browser_example(regular_example)?;
             execute_wasm_bindgen(
                 &format!(
-                    "target/wasm32-unknown-unknown/debug/examples/{}.wasm",
+                    "target/wasm/wasm32-unknown-unknown/debug/examples/{}.wasm",
                     regular_example
                 ),
                 "gooey/examples/browser/pkg/",
@@ -92,6 +94,8 @@ fn build_regular_browser_example(name: &str) -> Result<(), devx_cmd::Error> {
         "frontend-browser",
         "--target",
         "wasm32-unknown-unknown",
+        "--target-dir",
+        "target/wasm",
     )
 }
 


### PR DESCRIPTION
Closes #10

This also contains a few bug fixes:
- CSS Padding order was wrong. I don't know where I got the wrong order, but
  the "right" order really is wonky to me.
- Layout now preserves insertion-order so that transmogrifiers can produce
  consistent results.
- xtask now uses its own target folder, and wasm example compilation
  also uses its own target folder. This amplifies the amount of disk
  usage, but it means:
  - wasm builds won't clobber non-wasm builds
  - xtask generate-code-coverage-report will not clean its own build