### PR TITLE
Add API for tracking checked to the inner_size of a window

### DIFF
--- a/examples/window-properties.rs
+++ b/examples/window-properties.rs
@@ -1,0 +1,22 @@
+use gooey::value::Dynamic;
+use gooey::widget::{MakeWidget, WidgetInstance};
+use gooey::Run;
+use kludgine::figures::Size;
+
+fn main() -> gooey::Result {
+    let focused = Dynamic::new(false);
+    let occluded = Dynamic::new(false);
+    let inner_size = Dynamic::new(Size::default());
+
+    let widgets = focused.map_each(|v| format!("focused: {:?}", v))
+        .and(occluded.map_each(|v| format!("occluded: {:?}", v)))
+        .and(inner_size.map_each(|v| format!("inner_size: {:?}", v)))
+        .into_rows()
+        .centered();
+
+    gooey::window::Window::<WidgetInstance>::for_widget(widgets)
+        .focused(focused)
+        .occluded(occluded)
+        .inner_size(inner_size)
+        .run()
+}


### PR DESCRIPTION
This matched the apis used for focused and occluded properties. I've added an example to demonstrate usage.

Closes #61 